### PR TITLE
Add warewulf sync harness to ood node

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -68,6 +68,7 @@
 
 #OpenOnDemand
   ood_nodename: "ood"
+  ood_ip_addr: 10.1.1.254
   ood_provision: true
 
 #Node Inventory - not in the Ansible inventory sense! Just for WW and Slurm config.

--- a/roles/ood/files/warewulf/bin/wwgetfiles
+++ b/roles/ood/files/warewulf/bin/wwgetfiles
@@ -1,0 +1,127 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+if [ -n "$SET_X" ]; then
+    set -x
+fi
+
+# Lock so more than one wwgetfiles cannot be ran
+LOCKF=/tmp/.wwgetfile.lock
+if [ ! -f ${LOCKF} ]; then
+    touch ${LOCKF}
+else
+    echo "ERROR: wwgetfiles already running"
+    exit 1
+fi
+
+if [ -f /warewulf/transports/http/functions ]; then
+    . /warewulf/transports/http/functions
+elif [ -f ./functions ]; then
+    # For debugging
+    . ./functions
+else
+    exit
+fi
+
+WWGETFILES_INTERVAL=${WWGETFILES_INTERVAL:-180}
+
+if [ -n "$WWGETFILES_INTERVAL" -a $WWGETFILES_INTERVAL -gt 0 ];then
+    if [ -n "$RANDOM" -a ! -f "/init" ]; then
+        if [ -z "$SLEEPTIME" ]; then
+            SLEEPTIME=`expr $RANDOM % $WWGETFILES_INTERVAL`
+        fi
+        sleep $SLEEPTIME
+    fi
+fi
+
+TIMESTAMP_FILE="$NEWROOT/tmp/.wwgetfiles_timestamp"
+if [ ! -d $NEWROOT/tmp/ ]; then
+    mkdir $NEWROOT/tmp/
+fi
+
+if [ "$1" = "-F" ]; then
+    rm -f "$TIMESTAMP_FILE"
+elif [ -f "$TIMESTAMP_FILE" ]; then
+    if [ -z "$NEWROOT" ]; then
+        TIMESTAMP=`cat $TIMESTAMP_FILE`
+    fi
+fi
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        TMPFILE=`mktemp`
+        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>/dev/null; then
+            cat $TMPFILE | while read id name uid gid mode timestamp path; do
+                basedir=`dirname $path`
+                case "$mode" in
+                    d*) ftype=d ; mode=`echo $mode | sed 's/^d//'` ;;
+                    l*) ftype=l ; mode=`echo $mode | sed 's/^l//'` ;;
+                    b*) ftype=b ; mode=`echo $mode | sed 's/^b//'` ;;
+                    c*) ftype=c ; mode=`echo $mode | sed 's/^c//'` ;;
+                    p*) ftype=p ; mode=`echo $mode | sed 's/^p//'` ;;
+                    s*) ftype=s ; mode=`echo $mode | sed 's/^s//'` ;;
+                    *)  ftype=f ;;
+                esac
+                if [ ! -d "$NEWROOT/$basedir" ]; then
+                    mkdir -p "$NEWROOT/$basedir"
+                fi
+                if wget -q -O "$NEWROOT/$path.ww$timestamp" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&fileid=$id"; then
+                    if [ "$ftype" = "l" ]; then
+                        ln -s -f `cat "$NEWROOT/$path.ww$timestamp"` "$NEWROOT/$path"
+                        rm -f "$NEWROOT/$path.ww$timestamp"
+                    elif [ "$ftype" = "d" ]; then
+                        if [ -e "$NEWROOT/$path" -a ! -d "$NEWROOT/$path" ]; then
+                            mv -f "$NEWROOT/$path" "$NEWROOT/$path.ww`date '+%Y%m%d%H%M%S'`"
+                        fi
+                        mkdir -m $mode -p "$NEWROOT/$path"
+                        chown -h $uid "$NEWROOT/$path"
+                        chgrp -h $gid "$NEWROOT/$path"
+                        if [ -f "$NEWROOT/$path.ww$timestamp" ]; then
+                            rm -f "$NEWROOT/$path.ww$timestamp";
+                        fi
+                    else
+                        if [ "$ftype" = "b" -o "$ftype" = "c" ]; then
+                            devno=`cat "$NEWROOT/$path.ww$timestamp"`
+                            major=`expr $devno / 256`
+                            minor=`expr $devno % 256`
+                            rm -f "$NEWROOT/$path.ww$timestamp"
+                            mknod -m $mode "$NEWROOT/$path.ww$timestamp" $ftype $major $minor
+                        elif [ "$ftype" = "p" ]; then
+                            rm -f "$NEWROOT/$path.ww$timestamp"
+                            mknod -m $mode "$NEWROOT/$path.ww$timestamp" p
+                        elif [ "$ftype" = "s" ]; then
+                            : # NOT ACTUALLY SUPPORTED!
+                        else
+                            chmod $mode "$NEWROOT/$path.ww$timestamp"
+                        fi
+                        mv "$NEWROOT/$path.ww$timestamp" "$NEWROOT/$path"
+                        chown $uid "$NEWROOT/$path"
+                        chgrp $gid "$NEWROOT/$path"
+                    fi
+                    echo $timestamp > $TIMESTAMP_FILE
+                else
+                    echo "ERROR: Could not download $name"
+                    rm -f $NEWROOT/$path.ww $NEWROOT/$path.ww$timestamp
+                    # Remove lock file
+                    rm -f ${LOCKF}
+                    exit 2
+                fi
+            done
+            rm -f $TMPFILE
+            # Remove lock file
+            rm -f ${LOCKF}
+            exit 0
+        fi
+        rm -f $TMPFILE
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done
+
+

--- a/roles/ood/files/warewulf/bin/wwgetnodeconfig
+++ b/roles/ood/files/warewulf/bin/wwgetnodeconfig
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+. /warewulf/transports/http/functions
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>/dev/null; then
+            exit 0
+        fi
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done

--- a/roles/ood/files/warewulf/bin/wwgetscript
+++ b/roles/ood/files/warewulf/bin/wwgetscript
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+. /warewulf/transports/http/functions
+
+
+case $1 in
+    pre)
+        TYPE="pre"
+    ;;
+    post)
+        TYPE="post"
+    ;;
+    runtime)
+        TYPE="runtime"
+    ;;
+    *)
+        echo "What type of script do you wish to download? ('pre' or 'post)"
+        exit 2
+    ;;
+esac
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>/dev/null; then
+            exit 0
+        fi
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done
+

--- a/roles/ood/files/warewulf/bin/wwgetvnfs
+++ b/roles/ood/files/warewulf/bin/wwgetvnfs
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+if [ -n "$SET_X" ]; then
+    set -x
+fi
+
+[ -f /etc/functions ] && . /etc/functions
+[ -f /warewulf/transports/http/functions ] && . /warewulf/transports/http/functions
+
+VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
+
+cd "${NEWROOT:-/}"
+
+while true; do
+    for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
+
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null; then
+            echo "ERROR: Could not create the fifo!"
+            exit 1
+        fi
+
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            
+            tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
+            TEE_PID=$!
+            
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>/dev/null &
+            EXTRACT_PID=$!
+            
+            md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
+            MD5SUM_PID=$!
+
+        else
+
+            gunzip < /tmp/vnfs-download | bsdtar -pxf - &
+            EXTRACT_PID=$!
+
+        fi
+
+        wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
+        msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
+
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >/dev/null 2>&1
+        WGETEXIT=$?
+
+        if [ "${WGETEXIT}" -eq 0 ]; then
+            wwsuccess
+
+            if [ -n "${TEE_PID:-}" ]; then
+                wait "${TEE_PID}" || true
+            fi
+
+            if [ -n "${MD5SUM_PID:-}" ]; then
+                wait "${MD5SUM_PID}" || true
+            fi
+
+            msg_gray "   * extracting"
+            {
+                wait "${EXTRACT_PID}" && wwsuccess
+            } || wwfailure
+        else
+            wwretrying
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>/dev/null || true
+            continue
+        fi
+
+        msg_gray "   * checksum ${WWVNFS_CHECKSUM:-}"
+         "   * checksum ${WWVNFS_CHECKSUM:-}"
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            CHECKSUM=$(cut -f1 -d " " /tmp/wwgetvnfs_checksum)
+            if [ "${CHECKSUM}" != "${WWVNFS_CHECKSUM:-}" ]; then
+                wwfailure
+                exit 2
+            fi
+            wwlogger "vnfs checksum ${WWVNFS_CHECKSUM} matches"
+            wwsuccess
+        else
+            wwskipped
+        fi
+
+        if [ -x "$NEWROOT/sbin/init" ] || [ -h "$NEWROOT/sbin/init" ]; then
+            exit 0
+        fi
+
+    done
+    throttled_sleep
+done
+
+exit 1

--- a/roles/ood/files/warewulf/transports/http/functions
+++ b/roles/ood/files/warewulf/transports/http/functions
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+if [ -f "/etc/network.conf" ]; then
+    . /etc/network.conf
+fi
+
+if [ -f "/warewulf/config" ]; then
+    . /warewulf/config
+fi
+
+START=0
+BACKOFF=2
+INTERVALS=30
+COUNT=1
+export START BACKOFF INTERVALS COUNT
+
+if [ -z "$WWMASTER" ]; then
+    WWMASTER=`sed -e '/ wwmaster=/!d;s/.*wwmaster=\([^ ]*\).*/\1/' /proc/cmdline`
+    export WWMASTER
+fi
+
+if [ -z "$WWMASTER" ]; then
+    if [ -n "$DHCP_SERVER" ]; then
+        WWMASTER=$DHCP_SERVER
+    else
+        echo "ERROR: Could not identify master node!"
+        exit 2
+    fi
+fi
+
+
+throttled_sleep() {
+    if [ $COUNT -ge $INTERVALS ]; then
+        exit 2
+    fi
+    COUNT=`expr $COUNT + 1`
+    START=`expr $START + $BACKOFF`
+    sleep $START
+}
+

--- a/roles/ood/files/warewulf/transports/http/wwgetfiles
+++ b/roles/ood/files/warewulf/transports/http/wwgetfiles
@@ -1,0 +1,127 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+if [ -n "$SET_X" ]; then
+    set -x
+fi
+
+# Lock so more than one wwgetfiles cannot be ran
+LOCKF=/tmp/.wwgetfile.lock
+if [ ! -f ${LOCKF} ]; then
+    touch ${LOCKF}
+else
+    echo "ERROR: wwgetfiles already running"
+    exit 1
+fi
+
+if [ -f /warewulf/transports/http/functions ]; then
+    . /warewulf/transports/http/functions
+elif [ -f ./functions ]; then
+    # For debugging
+    . ./functions
+else
+    exit
+fi
+
+WWGETFILES_INTERVAL=${WWGETFILES_INTERVAL:-180}
+
+if [ -n "$WWGETFILES_INTERVAL" -a $WWGETFILES_INTERVAL -gt 0 ];then
+    if [ -n "$RANDOM" -a ! -f "/init" ]; then
+        if [ -z "$SLEEPTIME" ]; then
+            SLEEPTIME=`expr $RANDOM % $WWGETFILES_INTERVAL`
+        fi
+        sleep $SLEEPTIME
+    fi
+fi
+
+TIMESTAMP_FILE="$NEWROOT/tmp/.wwgetfiles_timestamp"
+if [ ! -d $NEWROOT/tmp/ ]; then
+    mkdir $NEWROOT/tmp/
+fi
+
+if [ "$1" = "-F" ]; then
+    rm -f "$TIMESTAMP_FILE"
+elif [ -f "$TIMESTAMP_FILE" ]; then
+    if [ -z "$NEWROOT" ]; then
+        TIMESTAMP=`cat $TIMESTAMP_FILE`
+    fi
+fi
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        TMPFILE=`mktemp`
+        if wget -q -O "$TMPFILE" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&timestamp=$TIMESTAMP" 2>/dev/null; then
+            cat $TMPFILE | while read id name uid gid mode timestamp path; do
+                basedir=`dirname $path`
+                case "$mode" in
+                    d*) ftype=d ; mode=`echo $mode | sed 's/^d//'` ;;
+                    l*) ftype=l ; mode=`echo $mode | sed 's/^l//'` ;;
+                    b*) ftype=b ; mode=`echo $mode | sed 's/^b//'` ;;
+                    c*) ftype=c ; mode=`echo $mode | sed 's/^c//'` ;;
+                    p*) ftype=p ; mode=`echo $mode | sed 's/^p//'` ;;
+                    s*) ftype=s ; mode=`echo $mode | sed 's/^s//'` ;;
+                    *)  ftype=f ;;
+                esac
+                if [ ! -d "$NEWROOT/$basedir" ]; then
+                    mkdir -p "$NEWROOT/$basedir"
+                fi
+                if wget -q -O "$NEWROOT/$path.ww$timestamp" "http://$master/WW/file?hwaddr=$WWINIT_HWADDR&fileid=$id"; then
+                    if [ "$ftype" = "l" ]; then
+                        ln -s -f `cat "$NEWROOT/$path.ww$timestamp"` "$NEWROOT/$path"
+                        rm -f "$NEWROOT/$path.ww$timestamp"
+                    elif [ "$ftype" = "d" ]; then
+                        if [ -e "$NEWROOT/$path" -a ! -d "$NEWROOT/$path" ]; then
+                            mv -f "$NEWROOT/$path" "$NEWROOT/$path.ww`date '+%Y%m%d%H%M%S'`"
+                        fi
+                        mkdir -m $mode -p "$NEWROOT/$path"
+                        chown -h $uid "$NEWROOT/$path"
+                        chgrp -h $gid "$NEWROOT/$path"
+                        if [ -f "$NEWROOT/$path.ww$timestamp" ]; then
+                            rm -f "$NEWROOT/$path.ww$timestamp";
+                        fi
+                    else
+                        if [ "$ftype" = "b" -o "$ftype" = "c" ]; then
+                            devno=`cat "$NEWROOT/$path.ww$timestamp"`
+                            major=`expr $devno / 256`
+                            minor=`expr $devno % 256`
+                            rm -f "$NEWROOT/$path.ww$timestamp"
+                            mknod -m $mode "$NEWROOT/$path.ww$timestamp" $ftype $major $minor
+                        elif [ "$ftype" = "p" ]; then
+                            rm -f "$NEWROOT/$path.ww$timestamp"
+                            mknod -m $mode "$NEWROOT/$path.ww$timestamp" p
+                        elif [ "$ftype" = "s" ]; then
+                            : # NOT ACTUALLY SUPPORTED!
+                        else
+                            chmod $mode "$NEWROOT/$path.ww$timestamp"
+                        fi
+                        mv "$NEWROOT/$path.ww$timestamp" "$NEWROOT/$path"
+                        chown $uid "$NEWROOT/$path"
+                        chgrp $gid "$NEWROOT/$path"
+                    fi
+                    echo $timestamp > $TIMESTAMP_FILE
+                else
+                    echo "ERROR: Could not download $name"
+                    rm -f $NEWROOT/$path.ww $NEWROOT/$path.ww$timestamp
+                    # Remove lock file
+                    rm -f ${LOCKF}
+                    exit 2
+                fi
+            done
+            rm -f $TMPFILE
+            # Remove lock file
+            rm -f ${LOCKF}
+            exit 0
+        fi
+        rm -f $TMPFILE
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done
+
+

--- a/roles/ood/files/warewulf/transports/http/wwgetnodeconfig
+++ b/roles/ood/files/warewulf/transports/http/wwgetnodeconfig
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+. /warewulf/transports/http/functions
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        if wget -q -O - "http://$master/WW/nodeconfig?hwaddr=$WWINIT_HWADDR" 2>/dev/null; then
+            exit 0
+        fi
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done

--- a/roles/ood/files/warewulf/transports/http/wwgetscript
+++ b/roles/ood/files/warewulf/transports/http/wwgetscript
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+. /warewulf/transports/http/functions
+
+
+case $1 in
+    pre)
+        TYPE="pre"
+    ;;
+    post)
+        TYPE="post"
+    ;;
+    runtime)
+        TYPE="runtime"
+    ;;
+    *)
+        echo "What type of script do you wish to download? ('pre' or 'post)"
+        exit 2
+    ;;
+esac
+
+while true; do
+    for master in `echo $WWMASTER | sed -e 's/,/ /g'`; do
+        if wget -q -O - "http://$master/WW/script?hwaddr=$WWINIT_HWADDR&type=$TYPE" 2>/dev/null; then
+            exit 0
+        fi
+    done
+    echo -n "." 1>&2
+    throttled_sleep
+done
+

--- a/roles/ood/files/warewulf/transports/http/wwgetvnfs
+++ b/roles/ood/files/warewulf/transports/http/wwgetvnfs
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright (c) 2001-2003 Gregory M. Kurtzer
+#
+# Copyright (c) 2003-2011, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+
+if [ -n "$SET_X" ]; then
+    set -x
+fi
+
+[ -f /etc/functions ] && . /etc/functions
+[ -f /warewulf/transports/http/functions ] && . /warewulf/transports/http/functions
+
+VALIDATE_VNFS="${WWVALIDATE_VNFS:-0}"
+
+cd "${NEWROOT:-/}"
+
+while true; do
+    for master in $(echo "${WWMASTER}" | sed -e 's/,/ /g'); do
+
+        rm -f /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null
+        if ! mkfifo /tmp/vnfs-download /tmp/vnfs-checksum /tmp/vnfs-extract 2>/dev/null; then
+            echo "ERROR: Could not create the fifo!"
+            exit 1
+        fi
+
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            
+            tee /tmp/vnfs-extract < /tmp/vnfs-download > /tmp/vnfs-checksum &
+            TEE_PID=$!
+            
+            gunzip < /tmp/vnfs-extract | bsdtar -pxf - 2>/dev/null &
+            EXTRACT_PID=$!
+            
+            md5sum /tmp/vnfs-checksum > /tmp/wwgetvnfs_checksum &
+            MD5SUM_PID=$!
+
+        else
+
+            gunzip < /tmp/vnfs-download | bsdtar -pxf - &
+            EXTRACT_PID=$!
+
+        fi
+
+        wwlogger "vnfs ${WWVNFS_NAME}, ${WWVNFSID}, ${WWVNFS_CHECKSUM:-undef}"
+        msg_gray "   * fetching ${WWVNFS_NAME} (ID:${WWVNFSID})"
+
+        wget -q -O /tmp/vnfs-download "http://$master/WW/vnfs?hwaddr=$WWINIT_HWADDR" >/dev/null 2>&1
+        WGETEXIT=$?
+
+        if [ "${WGETEXIT}" -eq 0 ]; then
+            wwsuccess
+
+            if [ -n "${TEE_PID:-}" ]; then
+                wait "${TEE_PID}" || true
+            fi
+
+            if [ -n "${MD5SUM_PID:-}" ]; then
+                wait "${MD5SUM_PID}" || true
+            fi
+
+            msg_gray "   * extracting"
+            {
+                wait "${EXTRACT_PID}" && wwsuccess
+            } || wwfailure
+        else
+            wwretrying
+            kill "${EXTRACT_PID}" "${TEE_PID:-}" "${MD5SUM_PID:-}" 2>/dev/null || true
+            continue
+        fi
+
+        msg_gray "   * checksum ${WWVNFS_CHECKSUM:-}"
+         "   * checksum ${WWVNFS_CHECKSUM:-}"
+        if [ "${VALIDATE_VNFS}" -eq 1 ]; then
+            CHECKSUM=$(cut -f1 -d " " /tmp/wwgetvnfs_checksum)
+            if [ "${CHECKSUM}" != "${WWVNFS_CHECKSUM:-}" ]; then
+                wwfailure
+                exit 2
+            fi
+            wwlogger "vnfs checksum ${WWVNFS_CHECKSUM} matches"
+            wwsuccess
+        else
+            wwskipped
+        fi
+
+        if [ -x "$NEWROOT/sbin/init" ] || [ -h "$NEWROOT/sbin/init" ]; then
+            exit 0
+        fi
+
+    done
+    throttled_sleep
+done
+
+exit 1

--- a/roles/ood/files/wwupdatefiles
+++ b/roles/ood/files/wwupdatefiles
@@ -1,0 +1,1 @@
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * root WWGETFILES_INTERVAL=180 /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -144,7 +144,7 @@
   pause:
     seconds: 1
 
-- name: "sudo wwsh provision set ood -y --files dynamic_hosts,munge.key,slurm.conf"
+- name: "sudo wwsh provision set ood -y --files dynamic_hosts,munge.key,slurm.conf  --bootlocal=exit"
   pause:
     seconds: 90
 

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -55,13 +55,6 @@
     group: root
     mode: 0644
 
-- name: start and enable slurmd
-  service: 
-    name: slurmd
-    state: started
-    enabled: yes
-
-
 - name: Enable http service
   systemd:
     state: started
@@ -138,4 +131,19 @@
 - name: "sudo wwsh provision set ood --files dynamic_hosts,munge.key,slurm.conf"
   pause:
     seconds: 180
+
+- name: Force warewulf synchronization
+  shell: /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1
+
+- name: start and enable munge
+  service:
+    name: munge
+    state: started
+    enabled: yes
+
+- name: start and enable slurmd
+  service:
+    name: slurmd
+    state: started
+    enabled: yes
 

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -120,15 +120,15 @@
   pause:
     seconds: 1
 
-- name: "sudo wwsh node new ood"
+- name: "sudo wwsh node new ood -y"
   pause:
     seconds: 1
 
-- name: "sudo wwsh node set ood -I {{ ood_ip_addr }} --hwadd {{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}"
+- name: "sudo wwsh node set ood -y -I {{ ood_ip_addr }} --hwadd {{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}"
   pause:
     seconds: 1
 
-- name: "sudo wwsh provision set ood --files dynamic_hosts,munge.key,slurm.conf"
+- name: "sudo wwsh provision set ood -y --files dynamic_hosts,munge.key,slurm.conf"
   pause:
     seconds: 180
 

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -80,6 +80,17 @@
 - name: Set SELinux to permissive mode without reboot
   command: setenforce 0
 
+# Discovery avoids having to hard code the ethernet device number
+# it keys off the assigned static IP for the ood node and uses that
+# to discover the ethernet device and mac address for the node
+# adapted from: https://serverfault.com/a/852093
+- name: discover ethernet address for ood internal network
+  set_fact:
+    ood_macaddress: "{{ hostvars[inventory_hostname]['ansible_' + item]['macaddress'] }}"
+  when: hostvars[inventory_hostname]['ansible_' + item]['ipv4']['address'] == ood_ip_addr
+  with_items:
+    - "{{ hostvars[inventory_hostname]['ansible_interfaces'] }}"
+
 - name: install warewulf file synchronization
   copy:
     src: warewulf
@@ -124,7 +135,7 @@
   pause:
     seconds: 1
 
-- name: "sudo wwsh node set ood -y -I {{ ood_ip_addr }} --hwadd {{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}"
+- name: "sudo wwsh node set ood -y -I {{ ood_ip_addr }} --hwadd {{ ood_macaddress }}"
   pause:
     seconds: 1
 

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -130,7 +130,7 @@
 
 - name: "sudo wwsh provision set ood -y --files dynamic_hosts,munge.key,slurm.conf"
   pause:
-    seconds: 180
+    seconds: 90
 
 - name: Force warewulf synchronization
   shell: /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -122,3 +122,20 @@
     owner: root
     group: root
     mode: 755
+
+- name: "RUN THESE COMMAND ON OHPC MASTER TO COMPLETE REGISTRATION"
+  pause:
+    seconds: 1
+
+- name: "sudo wwsh node new ood"
+  pause:
+    seconds: 1
+
+- name: "sudo wwsh node set ood -I {{ ood_ip_addr }} --hwadd {{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}"
+  pause:
+    seconds: 1
+
+- name: "sudo wwsh provision set ood --files dynamic_hosts,munge.key,slurm.conf"
+  pause:
+    seconds: 180
+

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -17,7 +17,6 @@
 - name: Get OpenHPC repo
   yum: name={{ openhpc_release_rpm }} state=present update_cache=true
 
-
 - name: Install dependencies-nfs-utils, ohpc packages, ntp and other required tools.
   yum: name={{ item }} state=installed update_cache=true
   with_items:
@@ -87,3 +86,34 @@
 
 - name: Set SELinux to permissive mode without reboot
   command: setenforce 0
+
+- name: install warewulf file synchronization
+  copy:
+    src: warewulf
+    dest: /
+    owner: root
+    group: root
+
+- name: create custom warewulf config file for node
+  template:
+    src: wwnodeconf.j2
+    dest: /warewulf/config
+    owner: root
+    group: root
+    mode: 0640
+
+- name: add warewulf file sync via cron
+  copy:
+    src: wwupdatefiles
+    dest: /etc/cron.d
+    owner: root
+    group: root
+    mode: 0640
+
+- name: create log output dir for warewulf cron
+  file:
+    path: /var/log/warewulf
+    state: directory
+    owner: root
+    group: root
+    mode: 755

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -80,6 +80,10 @@
 - name: Set SELinux to permissive mode without reboot
   command: setenforce 0
 
+# Implement warewulf file synchrnoization for cluster integration
+# https://groups.io/g/OpenHPC-users/message/2084
+# https://groups.io/g/OpenHPC-users/message/2405
+
 # Discovery avoids having to hard code the ethernet device number
 # it keys off the assigned static IP for the ood node and uses that
 # to discover the ethernet device and mac address for the node
@@ -98,6 +102,7 @@
     owner: root
     group: root
 
+# ensure script files are executable
 - file:
     path: /warewulf/bin
     recurse: true

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -94,6 +94,11 @@
     owner: root
     group: root
 
+- file:
+    path: /warewulf/bin
+    recurse: true
+    mode: u+x,g+x
+
 - name: create custom warewulf config file for node
   template:
     src: wwnodeconf.j2

--- a/roles/ood/templates/wwnodeconf.j2
+++ b/roles/ood/templates/wwnodeconf.j2
@@ -1,4 +1,4 @@
-WWINIT_HWADDR={{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}
+WWINIT_HWADDR={{ ood_macaddress }}
 export WWINIT_HWADDR
 WWMASTER={{ headnode_private_ip }}
 export WWMASTER

--- a/roles/ood/templates/wwnodeconf.j2
+++ b/roles/ood/templates/wwnodeconf.j2
@@ -1,0 +1,16 @@
+WWINIT_HWADDR={{ hostvars[inventory_hostname].ansible_enp0s8.macaddress }}
+export WWINIT_HWADDR
+WWMASTER={{ headnode_private_ip }}
+export WWMASTER
+WWTRANSPORT=http
+export WWTRANSPORT
+WWNODENAME={{ ood_nodename }}
+export WWNODENAME
+WWCLUSTER=
+export WWCLUSTER
+WWDOMAIN=
+export WWDOMAIN
+WWGROUPS=
+export WWGROUPS
+WWFQDN=
+export WWFQDN


### PR DESCRIPTION
Using warewulf synchronization is the easiest way to get
important files like the slurm.conf, munge.key, and hosts file
onto the ood node in order for it to participate in the cluster, ie.
schedule jobs.

The warewulf harness is added during node provisioning but since
the ood node is not provisioned by warewulf we need to add this
harness manually.  The /warewulf directory and associated cron.d
entry are the key to enabling this synchronization.

Once in place the ood node simply needs to be registered in the ohpc
warewulf db by ethernet address and the registered files will be
copied.

This feature is based on the discussion thread:

https://groups.io/g/OpenHPC-users/topic/27331998#2402

and in particular the process outlined here:

https://groups.io/g/OpenHPC-users/message/2084

The config file is a template the takes its values via ansible from the provisioned ood node ethernet address and master IP variables.