### PR TITLE
Fix: slurm.conf ood nodename

### DIFF
--- a/roles/ohpc_install/templates/slurm_conf.j2
+++ b/roles/ohpc_install/templates/slurm_conf.j2
@@ -111,5 +111,5 @@ PartitionName=low  Nodes=c0 Default=YES MaxTime=2-00:00:00 State=UP
 
 #OOD
 {% if ood_provision %}
-NodeName=={{ ood_nodename }}
+NodeName={{ ood_nodename }}
 {% endif %}


### PR DESCRIPTION
fixed the syntax error in Nodename