### PR TITLE
Revert "Patch: compute node nfs mount point"

### DIFF
--- a/roles/compute_build_vnfs/tasks/main.yml
+++ b/roles/compute_build_vnfs/tasks/main.yml
@@ -115,7 +115,7 @@
      lineinfile: line="{{ headnode_private_ip }}:/home /home nfs nfsvers=3,rsize=1024,wsize=1024,cto 0 0" dest={{ compute_chroot_loc }}/etc/fstab state=present
 
    - name: put NFS opt mount info in image
-     lineinfile: line="{{ headnode_private_ip }}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3 0 0" dest={{ compute_chroot_loc }}/etc/fstab state=present
+     lineinfile: line="{{ headnode_private_ip }}:/opt/ohpc/pub /opt/ohpc/pub-master nfs nfsvers=3 0 0" dest={{ compute_chroot_loc }}/etc/fstab state=present
 
    - name: put NFS opt mount info in image
      lineinfile: line="{{ headnode_private_ip }}:/export /export nfs nfsvers=3 0 0" dest={{ compute_chroot_loc }}/etc/fstab state=present


### PR DESCRIPTION
Reverts jprorama/CRI_XCBC#30

The /export file system is actually the place to maintain a shared file namespace across the cluster in CRI_XCBC.  Will move Easybuild base dir there and achieve consistent naming that way.