### PR TITLE
Patch: reverse proxy hostname

### DIFF
--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -49,7 +49,7 @@
     path: /etc/ood/config/ood_portal.yml
     line: '{{ item }}'
   with_items:
-    - "host_regex: '{{ compute_node_glob }}.localdomain'"
+    - "host_regex: '{{ compute_node_glob }}'"
     - "node_uri: '/node'"
     - "rnode_uri: '/rnode'"
 

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -52,13 +52,14 @@
     dest: /etc/ood/config/apps/bc_desktop/submit/submit.yml.erb
 
 - name: Enable reverse proxy
-  lineinfile:
+  replace:
     path: /etc/ood/config/ood_portal.yml
-    line: '{{ item }}'
+    regexp: '{{ item.regexp }}'
+    replace: '{{ item.replace }}'
   with_items:
-    - "host_regex: '{{ compute_node_glob }}'"
-    - "node_uri: '/node'"
-    - "rnode_uri: '/rnode'"
+      - { regexp: "^#?host_regex:.*$", replace: "host_regex: '{{ compute_node_glob }}'" }
+      - { regexp: "^#?node_uri:.*$", replace: "node_uri: '/node'" }
+      - { regexp: "^#?rnode_uri:.*$", replace: "rnode_uri: '/rnode'" }
 
 - name: Stage http authz file for ood
   copy:

--- a/roles/ood/templates/cluster.yml
+++ b/roles/ood/templates/cluster.yml
@@ -12,12 +12,12 @@ v2:
       script_wrapper: |
         module purge
         %s
-      set_host: "host=$(hostname -A | awk '{print $1}')"
+      set_host: "host=$(hostname -s)"
     vnc:
       script_wrapper: |
         module purge
         export PATH="/opt/TurboVNC/bin:$PATH"
         export WEBSOCKIFY_CMD="/bin/websockify"
         %s
-      set_host: "host=$(hostname -A | awk '{print $1}')"
+      set_host: "host=$(hostname -s)"
 


### PR DESCRIPTION
Since the hostname -A doesn't always produce the same result as we desired, change it to hostname -s which shows only shortest hostname, e.g. c0. Also need to update reverse proxy setting to match the change we made.