### PR TITLE
Patch: Use network profile name without changing it

### DIFF
--- a/roles/pre_ohpc/tasks/main.yml
+++ b/roles/pre_ohpc/tasks/main.yml
@@ -62,18 +62,21 @@
      #command: nmcli con mod 'eth0' connection.id '{{ public_interface }}'
 
    - name: check network profile name
-     shell: nmcli con | grep '{{ private_interface }}'
-     register: network_profile_name
+     shell: nmcli con | grep '{{ private_interface }}' | awk '{print $1" "$2}'
+     register: private_network_profile_name
 
-   - name: modify the name of the network profile name
-     command: nmcli con mod 'System {{ private_interface }}' connection.id '{{ private_interface }}'
-     when: "'System' in network_profile_name.stdout"
+   - shell: nmcli con | grep '{{ public_interface }}' | awk '{print $1" "$2}'
+     register: public_network_profile_name
+
+#   - name: modify the name of the network profile name
+#     command: nmcli con mod 'System {{ private_interface }}' connection.id '{{ private_interface }}'
+#     when: "'System' in network_profile_name.stdout"
 
    - name: add private interface to internal zone via nmcli
-     command: nmcli connection modify {{ private_interface }} connection.zone internal
+     command: nmcli connection modify "{{ private_network_profile_name.stdout }}" connection.zone internal
 
    - name: add public interface to public zone via nmcli
-     command: nmcli connection modify {{ public_interface }} connection.zone public
+     command: nmcli connection modify "{{ public_network_profile_name.stdout }}" connection.zone public
 
 #   - name: restart dbus for firewalld :(
 #     service: name=dbus state=restarted


### PR DESCRIPTION
Since centos/7 box also use 'System {dev_name}'
and vagrant add new interface with 'System {dev_name}' as well
So instead of modifying it, which can potentially cause problem,
we get the name from system using nmcli command.