### PR TITLE
Add new OpenHPC.repo to pin the ohpc release to update 5

### DIFF
--- a/roles/prep_ood/files/OpenHPC.repo
+++ b/roles/prep_ood/files/OpenHPC.repo
@@ -1,0 +1,12 @@
+[OpenHPC]
+name=OpenHPC-1.3 - Base
+baseurl=http://build.openhpc.community/OpenHPC:/1.3/CentOS_7
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-OpenHPC-1
+
+[OpenHPC-updates]
+name=OpenHPC-1.3 - Updates
+baseurl=http://build.openhpc.community/OpenHPC:/1.3:/Update5/CentOS_7/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-OpenHPC-1
+

--- a/roles/prep_ood/tasks/main.yaml
+++ b/roles/prep_ood/tasks/main.yaml
@@ -2,6 +2,14 @@
 - name: Get OpenHPC repo
   yum: name={{ openhpc_release_rpm }} state=present update_cache=true
 
+- name: Pin OpenHPC repo to 1.3.5 release
+  copy:
+    src: OpenHPC.repo
+    dest: /etc/yum.repos.d/OpenHPC.repo
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Install dependencies-nfs-utils, ohpc packages, ntp and other required tools.
   yum: name={{ item }} state=installed update_cache=true
   with_items:


### PR DESCRIPTION
Use an explicit url in the Update stanza of the yum repo
file to prevent ohpc packages from going past the  1.3.5 release

This release appears to have introduce an error with slurm
environment setup that is impacting open on demand starting
a VNC job due to an exported job environment that does not include
HOME or other critical variables.