### PR TITLE
Update network interface name

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,8 +5,8 @@
 # curl -s https://github.com/openhpc/ohpc/releases/ | grep rpm | grep -v sle | grep -v strong  | sed 's/.*="\(.*\)".*".*".*/\1/'
 #
 # Headnode Info
-  public_interface: "enp0s3" # NIC that allows access to the public internet
-  private_interface: "enp0s8" #NIC that allows access to compute nodes
+  public_interface: "eth0" # NIC that allows access to the public internet
+  private_interface: "eth1" #NIC that allows access to compute nodes
   headnode_private_ip: "10.1.1.1"
   build_kernel_ver: '3.10.0-862.11.6.el7.x86_64' # `uname -r` at build time... for wwbootstrap
 


### PR DESCRIPTION
Since Centos/7 vagrant box doesn't use predictable network interface naming, e.g. enp0s3, enp0s8, etc, we have to change it back to tranditional naming scheme, e.g. eth0, eth1 ...