### PR TITLE
Fix EasyBuild bootstrap with python setuptools package upgrade

### DIFF
--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -18,6 +18,13 @@
     mode: "g+w"
     recurse: yes
 
+# EasyBuild bootstrap will fail with outdated setuptools on CentOS
+# This is a work-around that updates the sytem installed setuptools
+# Ideal solution is to provide a python specific to EasyBuild
+# likely via software collections
+- name: Fix EasyBuild setuptools dependency on version > 17.1
+  shell: pip install -U setuptools
+
 - name: Download EasyBuild bootstrap script
   get_url:
     url: https://raw.githubusercontent.com/easybuilders/easybuild-framework/develop/easybuild/scripts/bootstrap_eb.py


### PR DESCRIPTION
Upgrade the system python setuptools to latest version to avoid
a dependency error during EasyBuild bootstrap.
This is a simple work-around to update the package.
Ideal solution will likely be dedicated python for EB using
software collections.