### PR TITLE
Run warewulf sync immediately for ood node

### DIFF
--- a/roles/warewulf_sync/tasks/main.yaml
+++ b/roles/warewulf_sync/tasks/main.yaml
@@ -68,4 +68,4 @@
     seconds: 90
 
 - name: Force warewulf synchronization
-  shell: /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1
+  shell: WWGETFILES_INTERVAL=0 /warewulf/bin/wwgetfiles >/var/log/warewulf/wwgetfiles.log 2>&1


### PR DESCRIPTION
Add parameter to wwgetfiles to run immediately instead of
waiting the random backoff time.  This avoid unexpected
delays in playbook execution.