### PR TITLE
Default slurm 17.11.11 upgrade to true

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -110,6 +110,6 @@
   easybuild_sourcepath: "/tmp/source"
 
 #Slurm 17.11.11 patch
-  slurm_update: false
+  slurm_update: true
   slurm_17_11_11_url: "https://uab.box.com/shared/static/8tftck8vlpnf6lo8ax0xaoqdrp8z7d6h.gz"
   slurm_17_11_11_dest: "/vagrant/CRI_XCBC"


### PR DESCRIPTION
Set the slurm upgrade to true by default.  The version
of slurm 17.11.10 delivered with ohpc 1.3.6 Nov 2017 is
broken and prevents env sharing.  This upgrade is
required for a working open ondemand environment.