### PR TITLE
Feat enable slurm 17 11 11 repo on copr

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -4,6 +4,11 @@
 #The full list of available versions for CentOS can be generated via
 # curl -s https://github.com/openhpc/ohpc/releases/ | grep rpm | grep -v sle | grep -v strong  | sed 's/.*="\(.*\)".*".*".*/\1/'
 #
+#Copr Repos
+  enable_copr: true
+  copr_repos:
+    - "louistw/slurm-17.11.11-ohpc-1.3.6"
+
 # Headnode Info
   public_interface: "eth0" # NIC that allows access to the public internet
   private_interface: "eth1" #NIC that allows access to compute nodes

--- a/ohpc.yaml
+++ b/ohpc.yaml
@@ -5,7 +5,6 @@
     - { name: 'ohpc_install', tags: 'ohpc_install' }
     - { name: 'ohpc_config', tags: 'ohpc_config' }
     - { name: 'compute_build_vnfs', tags: 'compute_build_vnfs' }
-    - { name: 'slurm_17_11_11', tags: 'slurm_17_11_11', when: slurm_update }
     - { name: 'compute_build_nodes', tags: 'compute_build_nodes' }
     - { name: 'nodes_vivify', tags: 'nodes_vivify' }
     - { name: 'ohpc_add_easybuild', tags: 'ohpc_add_easybuild' }

--- a/ood.yaml
+++ b/ood.yaml
@@ -2,7 +2,6 @@
 - hosts: ood
   roles:
     - { name: 'prep_ood', tags: 'prep_ood' }
-    - { name: 'slurm_17_11_11', tags: 'slurm_17_11_11', when: slurm_update }
     - { name: 'ood', tags: 'ood' }
     - { name: 'warewulf_sync', tags: 'warewulf_sync' }
     - { name: 'ood_firewall_and_services', tags: 'ood_firewall_and_services' }

--- a/roles/pre_ohpc/tasks/main.yml
+++ b/roles/pre_ohpc/tasks/main.yml
@@ -38,6 +38,10 @@
 
    - name: get OpenHPC Repo #hardcoded version # :(
      yum: name={{ openhpc_release_rpm }} state=present
+
+   - name: Install Copr plugin for yum
+     yum: name=yum-plugin-copr state=present update_cache=true
+     when: enable_copr == true
  
    - name: install fail2ban # separate b/c it's in epel
      yum: name=fail2ban state=latest 

--- a/roles/pre_ohpc/tasks/main.yml
+++ b/roles/pre_ohpc/tasks/main.yml
@@ -42,6 +42,11 @@
    - name: Install Copr plugin for yum
      yum: name=yum-plugin-copr state=present update_cache=true
      when: enable_copr == true
+
+   - name: enable Copr Repos
+     shell: yum -y copr enable "{{ item }}"
+     with_items: "{{ copr_repos }}"
+     when: enable_copr == true
  
    - name: install fail2ban # separate b/c it's in epel
      yum: name=fail2ban state=latest 

--- a/roles/prep_ood/tasks/main.yaml
+++ b/roles/prep_ood/tasks/main.yaml
@@ -2,6 +2,10 @@
 - name: Get OpenHPC repo
   yum: name={{ openhpc_release_rpm }} state=present update_cache=true
 
+- name: Install Copr plugin for yum
+  yum: name=yum-plugin-copr state=present update_cache=true
+  when: enable_copr == true
+
 - name: Install dependencies-nfs-utils, ohpc packages, ntp and other required tools.
   yum: name={{ item }} state=installed update_cache=true
   with_items:

--- a/roles/prep_ood/tasks/main.yaml
+++ b/roles/prep_ood/tasks/main.yaml
@@ -6,6 +6,11 @@
   yum: name=yum-plugin-copr state=present update_cache=true
   when: enable_copr == true
 
+- name: enable Copr Repos
+  shell: yum -y copr enable "{{ item }}"
+  with_items: "{{ copr_repos }}"
+  when: enable_copr == true
+
 - name: Install dependencies-nfs-utils, ohpc packages, ntp and other required tools.
   yum: name={{ item }} state=installed update_cache=true
   with_items:


### PR DESCRIPTION
Making use of Fedora Copr service. Update slurm just as easy by `yum install`.