### PR TITLE
Patch synchronize lmod configuration across cluster

### DIFF
--- a/roles/compute_build_nodes/tasks/main.yml
+++ b/roles/compute_build_nodes/tasks/main.yml
@@ -68,7 +68,7 @@
 #       seconds: 180
 
    - name: set files to provision
-     command: wwsh -y provision set {{ compute_node_glob }} --vnfs={{ compute_chroot }} --bootstrap={{ build_kernel_ver }} --files=passwd,group,shadow,munge.key,slurm.conf,dynamic_hosts,network --kargs="net.ifnames=1 biosdevname=1 quiet" --postnetdown=1
+     command: wwsh -y provision set {{ compute_node_glob }} --vnfs={{ compute_chroot }} --bootstrap={{ build_kernel_ver }} --files=passwd,group,shadow,munge.key,slurm.conf,dynamic_hosts,network,lmod.sh,lmod.csh --kargs="net.ifnames=1 biosdevname=1 quiet" --postnetdown=1
      when: node_inventory_auto == true
 
    - name: sync files #also generates dynamic hosts on headnode!

--- a/roles/compute_build_vnfs/tasks/main.yml
+++ b/roles/compute_build_vnfs/tasks/main.yml
@@ -147,6 +147,12 @@
    - name: wwimport file into image (munge)
      command: wwsh file import /etc/munge/munge.key
 
+   - name: wwimport file into image (lmod.sh)
+     command: wwsh file import /etc/profile.d/lmod.sh
+
+   - name: wwimport file into image (lmod.csh)
+     command: wwsh file import /etc/profile.d/lmod.csh
+
    - name: build bootstrap image
      shell: wwbootstrap {{ build_kernel_ver }}
 

--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -64,9 +64,13 @@
     backup: yes
   when: default_modulepath_csh.stdout == ""
 
+- name: Update file in warewulf file database
+  command: wwsh file sync
+
 - name: Verify EasyBuild installation
   shell: |
       source /opt/ohpc/admin/lmod/lmod/init/bash
       module use "{{ easybuild_prefix }}/modules/all"
       module load EasyBuild
       eb --version
+


### PR DESCRIPTION
We found that modulefiles path maintains by EasyBuild doesn't update to the MODULEPATH on compute node because lmod.sh and lmod.csh are not synchronized across cluster. This patch add these two files into warewulf file database so compute node can get updated file.