### PR TITLE
Uninstall slurmd on ood node

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -69,7 +69,6 @@
 #OpenOnDemand
   ood_nodename: "ood"
   ood_ip_addr: 10.1.1.254
-  ood_provision: true
 
 #Node Inventory - not in the Ansible inventory sense! Just for WW and Slurm config.
 # Someday I will need a role that can run wwnodescan, and add nodes to this file! Probably horrifying practice.

--- a/roles/ohpc_firewall_and_services/tasks/main.yaml
+++ b/roles/ohpc_firewall_and_services/tasks/main.yaml
@@ -4,9 +4,3 @@
     name: munge
     state: started
     enabled: yes
-
-- name: start and enable slurmd
-  service:
-    name: slurmd
-    state: started
-    enabled: yes

--- a/roles/ohpc_install/templates/slurm_conf.j2
+++ b/roles/ohpc_install/templates/slurm_conf.j2
@@ -108,8 +108,3 @@ NodeName=c0 Sockets=1 CoresPerSocket=1 State=UNKNOWN
 #PartitionName=high Nodes=compute-[0-1] Default=YES MaxTime=INFINITE State=UP PriorityTier=10
 #PartitionName=gpu  Nodes=gpu-compute-1 Default=YES MaxTime=INFINITE State=UP PriorityTier=5 AllowGroups=slurmusers
 PartitionName=low  Nodes=c0 Default=YES MaxTime=2-00:00:00 State=UP
-
-#OOD
-{% if ood_provision %}
-NodeName={{ ood_nodename }}
-{% endif %}

--- a/roles/prep_ood/tasks/main.yaml
+++ b/roles/prep_ood/tasks/main.yaml
@@ -16,7 +16,7 @@
   with_items:
     - nfs-utils
     - ohpc-base-compute
-    - ohpc-slurm-client
+    - slurm-ohpc
     - zsh
     - git
     - vim


### PR DESCRIPTION
Since we do not need slurmd running for just submit job, this patch removes `ohpc-slurm-client` and install only `slurm-ohpc` which is enough for our current need.

package `slurm-ohpc` will install all slurm executables, e.g. srun, sbatch, sinfo, etc.

NOTE: it does not install slurm-pam_slurm-ohpc which is fine for now, but we may want to add it back in the future.