### PR TITLE
Enable SCL using Yum or rhsm_repository depending on the OS

### DIFF
--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -3,6 +3,13 @@
   yum:
     name: "centos-release-scl"
     state: present
+  when: ansible_distribution == "CentOS"
+
+- name: Enable the Software Collections repository on RHEL 7
+  rhsm_repository:
+    name: rhel-server-rhscl-7-rpms
+    state: enabled
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version == '7'
 
 - name: Add Open OnDemand’s repository hosted by the Ohio Supercomputer Center
   yum:


### PR DESCRIPTION
Feature - Added code to main.yaml to conditionally install the SCL
repository on CentOS (via `yum`) or RHEL 7 (via `rhsm_repository`)

On branch feat-ood-add-rhel7-scl

* Changes to be committed:
  *	modified:   roles/ood/tasks/main.yaml