### PR TITLE
Add shibboleth SSO authn role and configuration for samltest.id

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -113,3 +113,7 @@
   enable_copr: true
   copr_repos:
     - { repo_name: "louistw/slurm-17.11.11-ohpc-1.3.6", host: ["{{ cluster_name }}", "{{ ood_nodename }}"] }
+    - { repo_name: "atlurie/shibboleth-3.0-ood", host: ["{{ ood_nodename }}"] }
+
+# Shibboleth SSO
+  enable_shib: false

--- a/ood.yaml
+++ b/ood.yaml
@@ -6,3 +6,4 @@
     - { name: 'warewulf_sync', tags: 'warewulf_sync' }
     - { name: 'ood_firewall_and_services', tags: 'ood_firewall_and_services' }
     - { name: 'ohpc_firewall_and_services', tags: 'ohpc_firewall_and_services' }
+    - { name: 'ood_shib_sso', tags: 'ood_shib_sso', when: enable_shib }

--- a/roles/ood_shib_sso/files/ood-user-mapfile
+++ b/roles/ood_shib_sso/files/ood-user-mapfile
@@ -1,0 +1,3 @@
+"msmith@samltest.id" vagrant
+"rsanchez@samltest.id" vagrant
+"scooper@samltest.id" vagrant

--- a/roles/ood_shib_sso/files/shibboleth2.xml
+++ b/roles/ood_shib_sso/files/shibboleth2.xml
@@ -1,0 +1,125 @@
+<SPConfig xmlns="urn:mace:shibboleth:3.0:native:sp:config"
+    xmlns:conf="urn:mace:shibboleth:3.0:native:sp:config"
+    clockSkew="180">
+
+    <OutOfProcess tranLogFormat="%u|%s|%IDP|%i|%ac|%t|%attr|%n|%b|%E|%S|%SS|%L|%UA|%a" />
+  
+    <!--
+    By default, in-memory StorageService, ReplayCache, ArtifactMap, and SessionCache
+    are used. See example-shibboleth2.xml for samples of explicitly configuring them.
+    -->
+
+    <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
+    <ApplicationDefaults entityID="https://testshib.dev.rc.uab.edu:8080/shibboleth"
+        REMOTE_USER="eppn subject-id pairwise-id persistent-id"
+        cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
+
+        <!--
+        Controls session lifetimes, address checks, cookie handling, and the protocol handlers.
+        Each Application has an effectively unique handlerURL, which defaults to "/Shibboleth.sso"
+        and should be a relative path, with the SP computing the full value based on the virtual
+        host. Using handlerSSL="true" will force the protocol to be https. You should also set
+        cookieProps to "https" for SSL-only sites. Note that while we default checkAddress to
+        "false", this makes an assertion stolen in transit easier for attackers to misuse.
+        -->
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+                  checkAddress="false" handlerSSL="false" cookieProps="http">
+
+            <!--
+            Configures SSO for a default IdP. To properly allow for >1 IdP, remove
+            entityID property and adjust discoveryURL to point to discovery service.
+            You can also override entityID on /Login query string, or in RequestMap/htaccess.
+            -->
+            <SSO entityID="https://samltest.id/saml/idp">SAML2 </SSO>
+	    <!--
+            <SSO entityID="https://samltest.id/saml/idp"
+                 discoveryProtocol="SAMLDS" discoveryURL="https://ds.example.org/DS/WAYF">
+              SAML2
+            </SSO>
+            -->
+            <!-- SAML and local-only logout. -->
+            <Logout>SAML2 Local</Logout>
+
+            <!-- Administrative logout. -->
+            <LogoutInitiator type="Admin" Location="/Logout/Admin" acl="127.0.0.1 ::1" />
+          
+            <!-- Extension service that generates "approximate" metadata based on SP configuration. -->
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="false"/>
+
+            <!-- Status reporting service. -->
+            <Handler type="Status" Location="/Status" acl="127.0.0.1 ::1"/>
+
+            <!-- Session diagnostic service. -->
+            <Handler type="Session" Location="/Session" showAttributeValues="false"/>
+
+            <!-- JSON feed of discovery information. -->
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+        </Sessions>
+
+        <!--
+        Allows overriding of error template information/filenames. You can
+        also add your own attributes with values that can be plugged into the
+        templates, e.g., helpLocation below.
+        -->
+        <Errors supportContact="root@localhost"
+            helpLocation="/about.html"
+            styleSheet="/shibboleth-sp/main.css"/>
+
+        <!-- Example of locally maintained metadata. -->
+        <!--
+        <MetadataProvider type="XML" validate="true" path="partner-metadata.xml"/>
+        -->
+
+<MetadataProvider type="XML" validate="true"
+        url="https://samltest.id/saml/idp"
+        backingFilePath="SAMLtest.xml">
+     <!-- You should always check the signature and freshness of remote
+                       metadata.  It's commented out until you get the basics working.
+          <MetadataFilter type="RequireValidUntil" maxValidityInterval="2419200"/>
+          <MetadataFilter type="Signature" certificate="signet.crt" verifyBackup="false"/>
+        -->
+</MetadataProvider>
+        <!-- Example of remotely supplied batch of signed metadata. -->
+        <!--
+        <MetadataProvider type="XML" validate="true"
+	            url="http://federation.org/federation-metadata.xml"
+              backingFilePath="federation-metadata.xml" maxRefreshDelay="7200">
+            <MetadataFilter type="RequireValidUntil" maxValidityInterval="2419200"/>
+            <MetadataFilter type="Signature" certificate="fedsigner.pem" verifyBackup="false"/>
+            <DiscoveryFilter type="Blacklist" matcher="EntityAttributes" trimTags="true" 
+              attributeName="http://macedir.org/entity-category"
+              attributeNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+              attributeValue="http://refeds.org/category/hide-from-discovery" />
+        </MetadataProvider>
+        -->
+
+        <!-- Example of remotely supplied "on-demand" signed metadata. -->
+        <!--
+        <MetadataProvider type="MDQ" validate="true" cacheDirectory="mdq"
+	            baseUrl="http://mdq.federation.org" ignoreTransport="true">
+            <MetadataFilter type="RequireValidUntil" maxValidityInterval="2419200"/>
+            <MetadataFilter type="Signature" certificate="mdqsigner.pem" />
+        </MetadataProvider>
+        -->
+
+        <!-- Map to extract attributes from SAML assertions. -->
+        <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
+
+        <!-- Default filtering policy for recognized attributes, lets other data pass. -->
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
+
+        <!-- Simple file-based resolvers for separate signing/encryption keys. -->
+        <CredentialResolver type="File" use="signing"
+            key="sp-signing-key.pem" certificate="sp-signing-cert.pem"/>
+        <CredentialResolver type="File" use="encryption"
+            key="sp-encrypt-key.pem" certificate="sp-encrypt-cert.pem"/>
+        
+    </ApplicationDefaults>
+    
+    <!-- Policies that determine how to process and authenticate runtime messages. -->
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
+
+    <!-- Low-level configuration about protocols and bindings available for use. -->
+    <ProtocolProvider type="XML" validate="true" reloadChanges="false" path="protocols.xml"/>
+
+</SPConfig>

--- a/roles/ood_shib_sso/tasks/main.yml
+++ b/roles/ood_shib_sso/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+  # Implement web single sign on support using shibboleth
+
+# note the copr repo for shibboleth was added during node prep roles
+- name: install shibboleth rpm for scl apache
+  yum: name=shibboleth state=latest
+
+# note the shibboleth rpm is not fully scl-yet so need hand correction
+- name: copy shibbolth apache module into ood scl installe
+  copy:
+    src: /etc/httpd/conf.d/shib.conf
+    dest: /opt/rh/httpd24/root/etc/httpd/conf.d/
+    remote_src: yes
+
+- name: enable shibd on boot
+  service:
+    name: shibd
+    enabled: yes
+
+# this loads a stock shibboleth config that will work with rpm-provided
+# shibboleth credentials against the samltest.id
+# must use the SP target host name testshib.dev.rc.uab.edu for ood node
+# from client running web browser.  e.g. edit /etc/hosts to map to localhost
+# also requires ood to be accessible on port 8080 to match entityID
+# note testshib.dev.rc.uab.edu is not a real Hostname
+- name: load samltest.id shibboleth config
+  copy:
+    src: shibboleth2.xml
+    dest: /etc/shibboleth/shibboleth2.xml
+
+- name: add saml-to-ood user map file
+  copy:
+    src: ood-user-mapfile
+    dest: /etc/ood/ood-user-mapfile
+
+- name: update ood portal config with user mapfile
+  replace:
+    path: /etc/ood/config/ood_portal.yml
+    regexp: '^#user_map_cmd:.*$'
+    replace: "user_map_cmd: '/opt/ood/ood_auth_map/bin/ood_auth_map.mapfile --file /etc/ood/ood-user-mapfile'\nuser_env: 'REMOTE_USER'\n"
+    backup: yes
+
+- name: update ood portal config for shibboleth authn
+  replace:
+    path: /etc/ood/config/ood_portal.yml
+    regexp: "^(#  - 'Require valid-user')"
+    replace: '\1\nauth:\n - "AuthType shibboleth"\n - "ShibRequestSetting requireSession 1"\n - "Require valid-user"\n'
+    backup: yes
+
+- name: Build the updated Apache config
+  command: /opt/ood/ood-portal-generator/sbin/update_ood_portal
+  ignore_errors: yes
+
+- name: start shibd
+  service:
+    name: shibd
+    state: started
+
+- name: Restart service httpd, in all cases
+  service:
+    name: httpd24-httpd
+    state: restarted

--- a/roles/ood_shib_sso/tasks/main.yml
+++ b/roles/ood_shib_sso/tasks/main.yml
@@ -12,11 +12,6 @@
     dest: /opt/rh/httpd24/root/etc/httpd/conf.d/
     remote_src: yes
 
-- name: enable shibd on boot
-  service:
-    name: shibd
-    enabled: yes
-
 # this loads a stock shibboleth config that will work with rpm-provided
 # shibboleth credentials against the samltest.id
 # must use the SP target host name testshib.dev.rc.uab.edu for ood node
@@ -51,10 +46,11 @@
   command: /opt/ood/ood-portal-generator/sbin/update_ood_portal
   ignore_errors: yes
 
-- name: start shibd
+- name: start shibd and enable on boot
   service:
     name: shibd
     state: started
+    enabled: yes
 
 - name: Restart service httpd, in all cases
   service:


### PR DESCRIPTION
This adds a role to enable shibboleth SSO authn for ood. It includes
a stock Shibboleth SP configuration for testing against the
https://samltest.id Shibboleth IdP. The stock IdP accounts are mapped
to the stock dev account (vagrant).

* groups_vars/all: enable copr repo for scl shib rpm, shib enable flag
* ood.yaml: optional role ood_shib_sso for shib sso
* tasks/main.yml: tasks for shib enabling and configuration
* files/shibboleth2.xml: configuration for samltest.id federation
* files/ood-user-mapfile: account mapping for upstream IdP accounts