### PR TITLE
Fix the missing yum repo for shibboleth and dependencies

### DIFF
--- a/roles/ood_shib_sso/tasks/main.yml
+++ b/roles/ood_shib_sso/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
   # Implement web single sign on support using shibboleth
 
+# Shibboleth repo config from
+# https://shibboleth.net/downloads/service-provider/latest/RPMS/
+- name: Add shibboleth openSUSE build service repository
+  yum_repository:
+    name: shibboleth
+    description: Shibboleth (CentOS_7)
+    mirrorlist: https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_7
+    gpgkey: https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
+    gpgcheck: yes
+    enabled: yes
+
 # note the copr repo for shibboleth was added during node prep roles
 - name: install shibboleth rpm for scl apache
   yum: name=shibboleth state=latest


### PR DESCRIPTION
This repo is needed to ensure all dependent rpms are installed
when shibboleth is installed.

Fixes issue #57