### PR TITLE
WIP: fix-slurmdbd-communication-error

### DIFF
--- a/roles/ohpc_install/tasks/main.yml
+++ b/roles/ohpc_install/tasks/main.yml
@@ -70,6 +70,10 @@
        state: started
        enabled: yes
 
+   - name: Add delay for slurmdbd to register the Cluster 
+     pause:
+       seconds: 5
+
    - name: load sacctmgr config
      command: sacctmgr -i load /etc/slurm/sacctmgr-heirarchy.cfg
 


### PR DESCRIPTION
The Cluster is not being registered with slurm database before sacctmgr started its business.
so sacctmgr is not able to load it's config file.
For the cluster name to be registered in time for the sacctmgr to operate we added
a 5 sec delay.