### PR TITLE
Feat ood appname in slurm

### DIFF
--- a/roles/ood_add_rstudio/files/submit.yml
+++ b/roles/ood_add_rstudio/files/submit.yml
@@ -8,6 +8,7 @@ script:
     - "--mem-per-cpu=<%= bc_num_mems.blank? ? 4 : bc_num_mems.to_i %>G"
     - "--partition=<%= bc_partition %>"
     - "--time=<%= bc_num_hours.blank? ? 1 : bc_num_hours.to_i %>:00:00"
+    - "--job-name=ood-rstudio-<%= version.split("/")[-1] %>"
 <%- if bc_partition == "pascalnodes" -%>
     - "--gres=gpu:1"
 <%- end -%>

--- a/roles/ood_add_rstudio/files/submit.yml
+++ b/roles/ood_add_rstudio/files/submit.yml
@@ -8,7 +8,7 @@ script:
     - "--mem-per-cpu=<%= bc_num_mems.blank? ? 4 : bc_num_mems.to_i %>G"
     - "--partition=<%= bc_partition %>"
     - "--time=<%= bc_num_hours.blank? ? 1 : bc_num_hours.to_i %>:00:00"
-    - "--job-name=ood-rstudio-<%= version.split("/")[-1] %>"
+    - "--job-name=ood-r-<%= version.split("/")[-1] %>"
 <%- if bc_partition == "pascalnodes" -%>
     - "--gres=gpu:1"
 <%- end -%>

--- a/roles/ood_jupyter/files/jupyter-submit.yml.erb
+++ b/roles/ood_jupyter/files/jupyter-submit.yml.erb
@@ -16,6 +16,7 @@ script:
     - "--mem-per-cpu=<%= bc_num_mems.blank? ? 4 : bc_num_mems.to_i %>G"
     - "--partition=<%= bc_partition %>"
     - "--time=<%= bc_num_hours.blank? ? 1 : bc_num_hours.to_i %>:00:00"
+    - "--job-name=ood-jupyter"
 <%- if bc_partition == "pascalnodes" -%>
     - "--gres=gpu:1"
 <%- end -%>

--- a/roles/ood_vnc_form/files/vnc-submit.yml.erb
+++ b/roles/ood_vnc_form/files/vnc-submit.yml.erb
@@ -6,6 +6,7 @@ script:
     - "--mem-per-cpu=<%= bc_num_mems.blank? ? 4 : bc_num_mems.to_i %>G"
     - "--partition=<%= bc_partition %>"
     - "--time=<%= bc_num_hours.blank? ? 1 : bc_num_hours.to_i %>:00:00"
+    - "--job-name=ooc-vnc"
 <%- if bc_partition == "pascalnodes" -%>
     - "--gres=gpu:1"
 <%- end -%>

--- a/roles/ood_vnc_form/files/vnc-submit.yml.erb
+++ b/roles/ood_vnc_form/files/vnc-submit.yml.erb
@@ -6,7 +6,7 @@ script:
     - "--mem-per-cpu=<%= bc_num_mems.blank? ? 4 : bc_num_mems.to_i %>G"
     - "--partition=<%= bc_partition %>"
     - "--time=<%= bc_num_hours.blank? ? 1 : bc_num_hours.to_i %>:00:00"
-    - "--job-name=ooc-vnc"
+    - "--job-name=ood-vnc"
 <%- if bc_partition == "pascalnodes" -%>
     - "--gres=gpu:1"
 <%- end -%>


### PR DESCRIPTION
By default, interactive job session launched by ood doesn't specify any job name in slurm context. it will show whole path to where the launch script is at. This PR defines job name for those jobs.

Specifically:
RStudio => `ood-rstudio-3.5.3`
Jupyter => `ood-jupyter`
VNC => `ood-vnc`

Add `ood-` prefix so user can distinguish from other jobs that is manually launch on cheaha. 