### PR TITLE
Feature define form attribute globally

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -148,3 +148,7 @@
   user_register_app_path: "/var/www/ood/register/{{ user_register_app }}"
   user_register_app_repo: "https://gitlab.rc.uab.edu/mmoo97/flask_user_reg.git"
   mod_wsgi_pkg_name: "uab-httpd24-mod_wsgi"
+
+# Slurm Partitions
+  partitions:
+    - { name: "low", hours: 1, max_nodes: 0, priority: 2 }

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -68,6 +68,7 @@
   with_items:
     - bc_partition
     - bc_num_mems
+    - bc_num_slots
 
 - name: Stage http authz file for ood
   copy:

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -67,6 +67,7 @@
     dest: /var/www/ood/apps/sys/dashboard/lib/smart_attributes/attributes
   with_items:
     - bc_partition
+    - bc_num_mems
 
 - name: Stage http authz file for ood
   copy:

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -61,6 +61,13 @@
       - { regexp: "^#?node_uri:.*$", replace: "node_uri: '/node'" }
       - { regexp: "^#?rnode_uri:.*$", replace: "rnode_uri: '/rnode'" }
 
+- name: Setup cluster-wise ood form attibutes
+  template:
+    src: "attributes/{{ item }}.rb"
+    dest: /var/www/ood/apps/sys/dashboard/lib/smart_attributes/attributes
+  with_items:
+    - bc_partition
+
 - name: Stage http authz file for ood
   copy:
     src: htpasswd

--- a/roles/ood/templates/attributes/bc_num_mems.rb
+++ b/roles/ood/templates/attributes/bc_num_mems.rb
@@ -1,0 +1,54 @@
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object with defined options
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::BCNumMems] the attribute object
+    def self.build_bc_num_mems(opts = {})
+      Attributes::BCNumMems.new("bc_num_mems", opts)
+    end
+  end
+
+  module Attributes
+    class BCNumMems < Attribute
+      # Hash of options used to define this attribute
+      # @return [Hash] attribute options
+      def opts
+        @opts.reverse_merge(min: 1, step: 1)
+      end
+
+      # Value of attribute
+      # Default to 4GB
+      # @return [String] attribute value
+      def value
+        (opts[:value] || "4").to_s
+      end
+
+      # Type of form widget used for this attribute
+      # @return [String] widget type
+      def widget
+        "number_field"
+      end
+
+      # Form label for this attribute
+      # @param fmt [String, nil] formatting of form label
+      # @return [String] form label
+      def label(fmt: nil)
+        str = opts[:label] || "Memory per CPU (GB)"
+      end
+
+      # Whether this attribute is required
+      # @return [Boolean] is required
+      def required
+        true
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(fmt: nil)
+        mems = value.blank? ? 1 : value.to_i
+        { script: { native: ["--mem-per-cpu=", mems] } }
+      end
+    end
+  end
+end

--- a/roles/ood/templates/attributes/bc_num_slots.rb
+++ b/roles/ood/templates/attributes/bc_num_slots.rb
@@ -1,0 +1,53 @@
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object with defined options
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::BCNumSlots] the attribute object
+    def self.build_bc_num_slots(opts = {})
+      Attributes::BCNumSlots.new("bc_num_slots", opts)
+    end
+  end
+
+  module Attributes
+    class BCNumSlots < Attribute
+      # Hash of options used to define this attribute
+      # @return [Hash] attribute options
+      def opts
+        @opts.reverse_merge(min: 1, step: 1)
+      end
+
+      # Value of attribute
+      # @return [String] attribute value
+      def value
+        (opts[:value] || "1").to_s
+      end
+
+      # Type of form widget used for this attribute
+      # @return [String] widget type
+      def widget
+        "number_field"
+      end
+
+      # Form label for this attribute
+      # @param fmt [String, nil] formatting of form label
+      # @return [String] form label
+      def label(fmt: nil)
+        str = opts[:label] || "Number of CPU"
+      end
+
+      # Whether this attribute is required
+      # @return [Boolean] is required
+      def required
+        true
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(fmt: nil)
+        slots = value.blank? ? 1 : value.to_i
+        { script: { native: ["-n", slots] } }
+      end
+    end
+  end
+end

--- a/roles/ood/templates/attributes/bc_partition.rb
+++ b/roles/ood/templates/attributes/bc_partition.rb
@@ -1,0 +1,41 @@
+module SmartAttributes
+  class AttributeFactory
+    # Build this attribute object with defined options
+    # @param opts [Hash] attribute's options
+    # @return [Attributes::BCPartition] the attribute object
+    def self.build_bc_partition(opts = {})
+      Attributes::BCPartition.new("bc_partition", opts)
+    end
+  end
+
+  module Attributes
+    class BCPartition < Attribute
+      # Type of form widget used for this attribute
+      # @return [String] widget type
+      def widget
+        "select"
+      end
+
+      # Form label for this attribute
+      # @param fmt [String, nil] formatting of form label
+      # @return [String] form label
+      def label(fmt: nil)
+        str = opts[:label] || "Partition"
+      end
+
+      def select_choices(fmt: nil)
+        parts = Array.new
+{% for part in partitions %}
+        parts.push(["{{ part.name }}", "{{ part.name }}"])
+{% endfor %}
+      end
+
+      # Submission hash describing how to submit this attribute
+      # @param fmt [String, nil] formatting of hash
+      # @return [Hash] submission hash
+      def submit(fmt: nil)
+        { script: { partition_name: value.blank? ? nil : value.strip } }
+      end
+    end
+  end
+end

--- a/roles/ood_add_rstudio/templates/form.yml
+++ b/roles/ood_add_rstudio/templates/form.yml
@@ -1,30 +1,6 @@
 ---
 cluster: "{{ cluster_name }}"
 attributes:
-  bc_num_hours:
-    value: 1
-
-  bc_num_slots:
-    label: Number of CPU
-    value: 1
-    min: 1
-    max: 24
-    step: 1
-
-  bc_num_mems:
-    widget: "number_field"
-    label: Memory per CPU (GB)
-    value: 4
-    min: 1
-    max: 128
-    step: 1
-
-  bc_partition:
-    widget: select
-    label: Partition
-    options:
-      - [ "low", "low" ]
-
   version:
     widget: select
     label: "R version"
@@ -34,6 +10,7 @@ attributes:
 {% for ver in r_versions %}
       - [ "{{ ver.full }}", "rstudio_singularity/{{ ver.full }}"]
 {% endfor %}
+
 form:
   - version
   - bc_num_hours

--- a/roles/ood_jupyter/templates/custom-jupyter-form.yml
+++ b/roles/ood_jupyter/templates/custom-jupyter-form.yml
@@ -62,30 +62,6 @@ attributes:
     widget: text_field
     label: Extra jupyter arguments
 
-  bc_num_hours:
-    value: 1
-
-  bc_num_slots:
-    label: Number of CPU
-    value: 1
-    min: 1
-    max: 24
-    step: 1
-
-  bc_num_mems:
-    widget: "number_field"
-    label: Memory per CPU (GB)
-    value: 4
-    min: 1
-    max: 128
-    step: 1
-
-  bc_partition:
-    widget: select
-    label: Partition
-    options:
-      - [ "low", "low" ]
-
 # All of the attributes that make up the Dashboard form (in respective order),
 # and made available to the submit configuration file and the template ERB
 # files

--- a/roles/ood_matlab/templates/form.yml
+++ b/roles/ood_matlab/templates/form.yml
@@ -1,36 +1,13 @@
 ---
 cluster: "{{ cluster_name }}"
 attributes:
-  bc_num_hours:
-    value: 1
-
-  bc_num_slots:
-    label: Number of CPU
-    value: 1
-    min: 1
-    max: 24
-    step: 1
-
-  bc_num_mems:
-    widget: "number_field"
-    label: Memory per CPU (GB)
-    value: 4
-    min: 1
-    max: 128
-    step: 1
-
-  bc_partition:
-    widget: select
-    label: Partition
-    options:
-      - [ "low", "low" ]
-
   version:
     widget: select
     label: "MATLAB version"
     help: "This defines the version of MATLAB you want to load."
     options:
       - [ "R2018a", "matlab/R2018a" ]
+
 form:
   - version
   - bc_num_hours

--- a/roles/ood_vnc_form/templates/cluster.yml
+++ b/roles/ood_vnc_form/templates/cluster.yml
@@ -4,26 +4,6 @@ cluster: {{ cluster_name }}
 submit: "submit/submit.yml.erb"
 attributes:
   desktop: "xfce"
-  bc_num_slots:
-    label: Number of CPU
-    value: 1
-    min: 1
-    max: 24
-    step: 1
-
-  bc_num_mems:
-    widget: "number_field"
-    label: Memory per CPU (GB)
-    value: 4
-    min: 1
-    max: 128
-    step: 1
-
-  bc_partition:
-    widget: select
-    label: Partition
-    options:
-      - [ "low", "low" ]
 
 form:
   - desktop


### PR DESCRIPTION
Define all of the attributes that should be shared across entire cluster as global attribute so we dont have to change it in each app:

`bc_partition`: partition for 
`bc_num_mems`: Memory per cpu (GB) 
`bc_num_slots`: OSC defined it as number of node for slurm, i changed it to be number of cpu.