### PR TITLE
fix-sacctmgr-w/dhcp-openstack 

### DIFF
--- a/roles/pre_ohpc/tasks/main.yml
+++ b/roles/pre_ohpc/tasks/main.yml
@@ -89,9 +89,6 @@
      command: nmcli con mod 'System {{ private_interface }}' connection.id '{{ private_interface }}'
      when: "'System' in network_profile_name.stdout"
 
-   - name: assign head node static ip on cluster network
-     command: nmcli con mod {{ private_interface }} ipv4.addresses {{ headnode_private_ip }}/24 ipv4.method manual
-
    - name: add private interface to internal zone via nmcli
      command: nmcli connection modify {{ private_interface }} connection.zone internal
 

--- a/roles/pre_ohpc/templates/hosts.j2
+++ b/roles/pre_ohpc/templates/hosts.j2
@@ -2,5 +2,5 @@
 ::1 localhost
 
 {% for host in groups['headnode'] %}
-{{ headnode_private_ip }} {{ hostvars[host]['inventory_hostname'] }}  {{ hostvars[host]['inventory_hostname'] }}.local
+{{ hostvars[inventory_hostname]['ansible_eth1']['ipv4']['address'] }} {{ hostvars[host]['inventory_hostname'] }}  {{ hostvars[host]['inventory_hostname'] }}.local
 {% endfor %}


### PR DESCRIPTION
This PR fixes the sacctmgr cmd failure after allocating an IP for the head node through DHCP due to the /etc/hosts file still using the statically assigned headnode_private_ip in group_vars/all file.