### PR TITLE
Feature per group app

### DIFF
--- a/roles/ood_group_app/tasks/main.yaml
+++ b/roles/ood_group_app/tasks/main.yaml
@@ -18,3 +18,14 @@
     owner: root
     group: "{{ app_group_name }}"
     mode: '0750'
+
+- git:
+    repo: "{{ app_repo }}"
+    dest: "/var/www/ood/apps/sys/{{ app_name }}/"
+    clone: yes
+  when: app_repo is defined
+
+- template:
+    src: "/var/www/ood/apps/sys/{{ app_name }}/form.yml"
+    dest: "/var/www/ood/apps/sys/{{ app_name }}/form.yml"
+  when: app_repo is defined

--- a/roles/ood_group_app/tasks/main.yaml
+++ b/roles/ood_group_app/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Create app folder
+  file:
+    path: "/var/www/ood/apps/sys/{{ app_name }}"
+    state: directory
+    owner: root
+    group: "{{ app_group_name }}"
+    mode: '0750'

--- a/roles/ood_group_app/tasks/main.yaml
+++ b/roles/ood_group_app/tasks/main.yaml
@@ -1,4 +1,16 @@
 ---
+- name: Ensure group exists
+  group:
+    name: "{{ app_group_name }}"
+    state: present
+
+- name: Add user into the group if provided
+  user:
+    name: "{{ item }}"
+    groups: "{{ app_group_name }}"
+  with_items: "{{ app_users }}"
+  when: app_users is defined and (app_users|length > 0)
+
 - name: Create app folder
   file:
     path: "/var/www/ood/apps/sys/{{ app_name }}"


### PR DESCRIPTION
Input:

- app_group_name: the group name for the app
- app_name: the application folder name to be created under `/var/www/ood/apps/sys/`
- app_usrs: (optional) the users to add into the group
- app_repo: (optional) the git repo to be cloned into application folder

Here is an example to add application `sas` which clone from github for group `app_grp` with users `centos` and `root`:
 
```
ansible localhost --playbook-dir=/CRI_XCBC  -m import_role -a name=ood_group_app -e "{'app_name':'sas','app_group_name':'app_grp','app_users':['centos'],'app_repo':'https://github.com/uabrc/ood_sas'}" -b
```