### PR TITLE
Change the playbook target to the headnode group name

### DIFF
--- a/ohpc-build.yaml
+++ b/ohpc-build.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: ohpc
+- hosts: headnode
   roles:
     - { name: 'pre_ohpc', tags: 'pre_ohpc' }
     - { name: 'ohpc_install', tags: 'ohpc_install' }

--- a/ohpc-ops.yaml
+++ b/ohpc-ops.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: ohpc
+- hosts: headnode
   roles:
     - { name: 'compute_build_nodes_cloud', tags: 'compute_build_nodes_cloud' }
     - { name: 'nodes_vivify_cloud', tags: 'nodes_vivify_cloud' }

--- a/ohpc.yaml
+++ b/ohpc.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: ohpc
+- hosts: headnode
   roles:
     - { name: 'pre_ohpc', tags: 'pre_ohpc' }
     - { name: 'ohpc_install', tags: 'ohpc_install' }


### PR DESCRIPTION
Using the group name for headnode instead of the ohpc host name
from the inventory in the playbooks makes it easier to build
images with custom host names.
It's also slightly more correct to use the group name instead of
the host name and aligns with other uses of group name in playbooks.