### PR TITLE
Patch fix easybuild error

### DIFF
--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -25,7 +25,7 @@
 # Ideal solution is to provide a python specific to EasyBuild
 # likely via software collections
 - name: Fix EasyBuild setuptools dependency on version > 17.1
-  shell: pip3 install -U setuptools wheel
+  shell: pip3 install -U pip setuptools wheel
 
 - name: Download EasyBuild bootstrap script
   get_url:

--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -4,7 +4,9 @@
     state: present
     name: 
       - '@Development Tools'
-      - python-pip
+      - python3
+      - python3-pip
+
 
 - name: Create user build
   user:

--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -25,7 +25,7 @@
 # Ideal solution is to provide a python specific to EasyBuild
 # likely via software collections
 - name: Fix EasyBuild setuptools dependency on version > 17.1
-  shell: pip install -U setuptools wheel
+  shell: pip3 install -U setuptools wheel
 
 - name: Download EasyBuild bootstrap script
   get_url:

--- a/roles/ohpc_add_easybuild/tasks/main.yaml
+++ b/roles/ohpc_add_easybuild/tasks/main.yaml
@@ -23,7 +23,7 @@
 # Ideal solution is to provide a python specific to EasyBuild
 # likely via software collections
 - name: Fix EasyBuild setuptools dependency on version > 17.1
-  shell: pip install -U setuptools
+  shell: pip install -U setuptools wheel
 
 - name: Download EasyBuild bootstrap script
   get_url:


### PR DESCRIPTION
This PR fixes the errors encountered during easy build bootstrapping due to 
1. outdated setuptools in python and 
2. wheel not being installed.
