### PR TITLE
Installing RabbitMQ on ood node

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -168,3 +168,7 @@
   user_create_scripts_path: "/opt/{{ user_create_scripts }}"
   user_create_script_repo: "https://gitlab.rc.uab.edu/tr27p/ohpc_user_create.git"
 
+# RabbitMQ
+  rabbitmq_provision: false
+  rabbitmq_user: "reggie"
+  rabbitmq_user_password: ""

--- a/ood-build.yaml
+++ b/ood-build.yaml
@@ -8,6 +8,7 @@
     - { name: 'ood_add_rstudio', tags: 'ood_add_rstudio', when: rstudio_provision }
     - { name: 'ood_matlab', tags: 'ood_matlab', when: matlab_provision }
     - { name: 'ood_sas', tags: 'ood_sas', when: sas_provision }
+    - { name: 'ood_rabbitmq', tags: 'ood_rabbitmq', when: rabbitmq_provision }
     - { name: 'install_ww_bin', tags: 'install_ww_bin' }
     - { name: 'ood_firewall_and_services', tags: 'ood_firewall_and_services' }
     - { name: 'ohpc_firewall_and_services', tags: 'ohpc_firewall_and_services' }

--- a/roles/ood_rabbitmq/tasks/main.yaml
+++ b/roles/ood_rabbitmq/tasks/main.yaml
@@ -1,0 +1,43 @@
+---
+- fail:
+    msg: Please pass in password for rabbitmq user
+  when: rabbitmq_user_password == ""
+
+- name: Import RabbitMQ signing key
+  rpm_key:
+    state: present
+    key: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+
+- name: Add RabbitMQ bintray repository
+  yum_repository:
+    name: bintray-rabbitmq-rpm
+    description: RabbitMQ (CentOS 7)
+    baseurl: https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.8.x/el/7/
+    gpgcheck: no
+    enabled: yes
+
+- name: Install Erlang
+  yum:
+    name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.2.3-1.el7.x86_64.rpm
+    state: present
+
+- name: Install RabbitMQ Server
+  yum:
+    name: rabbitmq-server
+    state: present
+
+- name: Start and enable RabbitMQ Server
+  service:
+    name: rabbitmq-server
+    state: started
+    enabled: yes
+
+- name: Add RabbitMQ user
+  rabbitmq_user:
+    user: "{{ rabbitmq_user }}"
+    password: "{{ rabbitmq_user_password }}"
+    vhost: /
+    configure_priv: .*
+    read_priv: .*
+    write_priv: .*
+    state: present


### PR DESCRIPTION
In `group_vars/all`, I leave password blank. When running playbook, pass in with arguments like this:
 `--extra-vars rabbitmq_user_password="YoUrPasSwOrd"`
So the command in packer build.json should be something like this:

```
   {
    "type": "shell",
    "inline": [
      "sudo ansible-playbook -c local -i /CRI_XCBC/hosts -l `hostname -s` /CRI_XCBC/site-build.yaml -b --extra-vars rabbitmq_user_password='YoUrPasSwOrd'"
    ]
   }
```