### PR TITLE
Fix the module name for rabbitmq_vhost and _user creation.

### DIFF
--- a/roles/ood_user_reg_cloud/tasks/main.yml
+++ b/roles/ood_user_reg_cloud/tasks/main.yml
@@ -114,12 +114,12 @@
     enabled: yes
 
 - name: Add Vhost in celery
-  celery_vhost:
+  rabbitmq_vhost:
     name: "{{ celery_vhost }}"
     state: present
 
 - name: Add User in celery
-  celery_user:
+  rabbitmq_user:
     user: "{{ celery_user }}"
     password: "{{ celery_user_password }}"
     vhost: "{{ celery_vhost }}"


### PR DESCRIPTION
The celery_vhost is an invalid name and causes ansible to fail
compile.