### PR TITLE
Deploy rabbitmq service and agents with enable_user_reg

### DIFF
--- a/ohpc-build.yaml
+++ b/ohpc-build.yaml
@@ -8,8 +8,8 @@
     - { name: 'ohpc_jupyter', tags: 'ohpc_jupyter', when: jupyter_provision}
     - { name: 'ohpc_matlab', tags: 'ohpc_matlab', when: matlab_provision }
     - { name: 'ohpc_sas', tags: 'ohpc_sas', when: sas_provision }
-    - { name: 'ohpc_rabbitmq', tags: 'ohpc_rabbitmq', when: rabbitmq_provision }
+    - { name: 'ohpc_rabbitmq', tags: 'ohpc_rabbitmq', when: enable_user_reg }
     - { name: 'ohpc_add_rstudio', tags: 'ohpc_add_rstudio', when: rstudio_provision }
     - { name: 'ohpc_user_reg', tags: 'ohpc_user_reg', when: enable_user_reg }
     - { name: 'reg_user_create_scripts', tags: 'reg_user_create_scripts', when: enable_user_create_scripts }
-    - { name: 'ohpc_add_rabbitmq_agents', tags: 'ohpc_add_rabbitmq_agents', when: rabbitmq_provision }
+    - { name: 'ohpc_add_rabbitmq_agents', tags: 'ohpc_add_rabbitmq_agents', when: enable_user_reg }

--- a/ood-build.yaml
+++ b/ood-build.yaml
@@ -13,4 +13,4 @@
     - { name: 'ohpc_firewall_and_services', tags: 'ohpc_firewall_and_services' }
     - { name: 'ood_user_reg_cloud', tags: 'ood_user_reg_cloud' }
     - { name: 'reg_user_create_scripts', tags: 'reg_user_create_scripts', when: enable_user_create_scripts }
-    - { name: 'ood_add_rabbitmq_agents', tags: 'ood_add_rabbitmq_agents', when: rabbitmq_provision }
+    - { name: 'ood_add_rabbitmq_agents', tags: 'ood_add_rabbitmq_agents', when: enable_user_reg }


### PR DESCRIPTION
Change to enable_user_reg flag for calling the rabbitmq server and agent
install playbooks so they are installed when the user_reg app
is installed.  These are dependancies of user_reg and should
be installed whenever that app is active.  The don't need to
have their own dedicated playbook flags.

Fixes #167