### PR TITLE
Fix - Rabbitmq agent services restart interval

### DIFF
--- a/roles/ohpc_add_rabbitmq_agents/files/ohpc_account.service
+++ b/roles/ohpc_add_rabbitmq_agents/files/ohpc_account.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=5
 User=centos
 ExecStart=/usr/bin/env python3 /opt/rabbitmq_agents/ohpc_account_create.py
 

--- a/roles/ohpc_add_rabbitmq_agents/files/slurm_account.service
+++ b/roles/ohpc_add_rabbitmq_agents/files/slurm_account.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=5
 User=centos
 ExecStart=/usr/bin/env python3 /opt/rabbitmq_agents/slurm_agent.py
 

--- a/roles/ood_add_rabbitmq_agents/files/ood_account.service
+++ b/roles/ood_add_rabbitmq_agents/files/ood_account.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=5
 User=centos
 ExecStart=/usr/bin/env python3 /opt/rabbitmq_agents/ood_account_create.py
 

--- a/roles/ood_user_reg_cloud/templates/celery.service
+++ b/roles/ood_user_reg_cloud/templates/celery.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
-RestartSec=1
+RestartSec=5
 User=centos
 WorkingDirectory={{ user_register_app_path }} 
 ExecStart=/usr/bin/env celery -A tasks worker --loglevel=info --concurrency=4

--- a/roles/ood_user_reg_cloud/templates/service.j2
+++ b/roles/ood_user_reg_cloud/templates/service.j2
@@ -3,8 +3,11 @@ Description=uWSGI server for flask user registration
 After=network.target
 
 [Service]
+Type=simple
 User={{ RegUser_app_user }}
 Group=apache
+Restart=always
+RestartSec=5
 WorkingDirectory={{ user_register_app_path }}
 Environment="PATH={{ user_register_app_path }}/venv/bin"
 ExecStart={{ user_register_app_path }}/venv/bin/uwsgi --ini {{ user_register_app }}.ini


### PR DESCRIPTION
Modifying restart seconds in the service file to overcome the default limit of 5 retries in 10 seconds