### PR TITLE
Update erlang version for rabbitmq

### DIFF
--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -18,7 +18,7 @@
 
 - name: Install Erlang
   yum:
-    name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.2.3-1.el7.x86_64.rpm
+    name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.3.4.2-1.el7.x86_64.rpm
     state: present
 
 - name: Install RabbitMQ Server


### PR DESCRIPTION
The erlang package version it out of date and the current package is no longer available.  Update to working release tag.