### PR TITLE
Set default passwords for rabbitmq accounts

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -172,9 +172,9 @@
 # RabbitMQ
   rabbitmq_provision: false
   rabbitmq_user: "reggie"
-  rabbitmq_user_password: ""
+  rabbitmq_user_password: "reggie"
 
 # Celery
   celery_user: "reggie"
-  celery_user_password: ""
+  celery_user_password: "reggie"
   celery_vhost: "socketio"


### PR DESCRIPTION
It's helpful to have defaults set so the builds don't fail.
They are public defaults so not mean for production deploys.