### PR TITLE
Add test accounts for user self reg

### DIFF
--- a/roles/ood/files/htpasswd
+++ b/roles/ood/files/htpasswd
@@ -1,1 +1,4 @@
 centos:$apr1$skdJeq64$2xEe6FBObbYeIsEOMwQaX/
+u1:$apr1$skdJeq64$2xEe6FBObbYeIsEOMwQaX/
+u2:$apr1$skdJeq64$2xEe6FBObbYeIsEOMwQaX/
+u3:$apr1$skdJeq64$2xEe6FBObbYeIsEOMwQaX/


### PR DESCRIPTION
Create additional accounts u1-u3 in htpasswd file so
those users are defined in the stand-in external upstream
idm so code for self-registration can easily be tested
at deploy.