### PR TITLE
Fix easybuild installation error

### DIFF
--- a/roles/ohpc_add_rstudio/tasks/main.yaml
+++ b/roles/ohpc_add_rstudio/tasks/main.yaml
@@ -4,7 +4,7 @@
     source /etc/profile.d/lmod.sh
     export EASYBUILD_PREFIX={{ easybuild_prefix }}
     module load EasyBuild
-    eb Singularity-{{ singularity_ver }}-GCC-5.4.0-2.26.eb --try-toolchain-name=dummy -r --force
+    eb Singularity-{{ singularity_ver }}-GCC-5.4.0-2.26.eb --toolchain-name=system -r --force
   become_user: build
   args:
     executable: /bin/bash

--- a/roles/ohpc_jupyter/tasks/main.yml
+++ b/roles/ohpc_jupyter/tasks/main.yml
@@ -4,7 +4,7 @@
     source /etc/profile.d/lmod.sh 
     export EASYBUILD_PREFIX={{ easybuild_prefix }}
     module load EasyBuild
-    eb Anaconda3-5.3.0.eb --try-toolchain-name=dummy -r --force
+    eb Anaconda3-5.3.0.eb --toolchain-name=system -r --force
   become_user: build
   args:
     executable: /bin/bash


### PR DESCRIPTION
Easybuild toolchain dummy has been deprecated causing installation errors
update with instructions recommended by Easybuild
https://easybuild.readthedocs.io/en/latest/System_toolchain.html#impact-of-deprecating-dummy-toolchain