### PR TITLE
Build and deploy a login image with OOD on Bright Cluster on Demand

### DIFF
--- a/bright-cod-login.yaml
+++ b/bright-cod-login.yaml
@@ -1,0 +1,4 @@
+---
+- hosts: headnode
+  roles:
+    - { name: 'cod_login_node', tags: 'cod_login_node' }

--- a/group_vars/all
+++ b/group_vars/all
@@ -54,6 +54,8 @@
   gpu_chroot: centos7-gpu
   login_chroot_loc: "/opt/ohpc/admin/images/{{ login_chroot }}"
   login_chroot: centos7-login 
+  bright_cod_login_chroot_loc: "/cm/images/{{ bright_cod_login_chroot }}"
+  bright_cod_login_chroot: login-image
 
 # Node Inventory method - automatic, or manual
   node_inventory_auto: false

--- a/hosts
+++ b/hosts
@@ -15,3 +15,6 @@ c[0:9]
 
 [compute:vars]
 sshgroup=compute
+
+[chroot]
+/cm/images/login-image	ansible_connection=chroot

--- a/ood-cod.yaml
+++ b/ood-cod.yaml
@@ -1,0 +1,14 @@
+---
+- hosts: chroot
+  roles:
+    - { name: 'ood', tags: 'ood' }
+    - { name: 'ood_jupyter', tags: 'ood_jupyter', when: jupyter_provision}
+    - { name: 'ood_vnc_form', tags: 'ood_vnc_form' }
+    - { name: 'ood_add_rstudio', tags: 'ood_add_rstudio', when: rstudio_provision }
+    - { name: 'ood_matlab', tags: 'ood_matlab', when: matlab_provision }
+    - { name: 'ood_sas', tags: 'ood_sas', when: sas_provision }
+    - { name: 'ood_firewall_and_services', tags: 'ood_firewall_and_services' }
+    - { name: 'ohpc_firewall_and_services', tags: 'ohpc_firewall_and_services' }
+    - { name: 'ood_shib_sso', tags: 'ood_shib_sso', when: enable_shib }
+    - { name: 'ood_user_reg_cloud', tags: 'ood_user_reg_cloud' }
+    - { name: 'ood_user_reg_ops', tags: 'ood_user_reg_ops' }

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -73,17 +73,5 @@
     state: started
     name: tftpd
 
-# Port security is not enabled on internal ports, by default from Heat template
-# So this step and the next would not be necessary.
-#- name: Get BOOTIF interface ID in openstack
-#  command: openstack port list | grep -w "login001_internal_port" | awk '{ print $2 }'
-#  register: eth0_id
-#
-#- name: Remove port security
-#  command: openstack port set {{ eth0_id }} {{ item }}
-#  loop:
-#    - --no-security-group
-#    - --disable-port-security
-
 - name: Reboot login001 to pick up the new image
   command: cmsh -c "device; use login001; reboot"

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -58,11 +58,11 @@
 - name: Set DHCP on BOOTIF device
   command: cmsh -c "device; use login001; interfaces; use bootif; set dhcp yes; commit"
 
-#- name: Add an extra interface to login from externalnet
-#  command: cmsh -c "device; use login001; addinterface -c login physical eth1 externalnet 192.168.200.1; commit"
+- name: Add an extra interface to login from externalnet
+  command: cmsh -c "device; use login001; addinterface -c login physical eth1 externalnet 192.168.200.1; commit"
 
-#- name: Set DHCP on the new interface added above
-#  command: cmsh -c "device; use login001; interfaces; use eth1; set dhcp yes; commit"
+- name: Set DHCP on the new interface added above
+  command: cmsh -c "device; use login001; interfaces; use eth1; set dhcp yes; commit"
 
 ## Non-provisioning interfaces are inactive unless they are explicitly brought up
 #- name: Set external interface eth1 to come up during install.

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -45,7 +45,7 @@
   command: git clone https://github.com/4the1appdevs/chname.git /cm/shared/apps/chname
 
 - name: Install chname to allow chroot env to be created with a desired hostname.
-  command: cd /cm/shared/apps/chname && make install
+  command: make -C /cm/shared/apps/chname install 
 
 - name: Enter chroot env for login image with hostname OOD
   command: chname ood chroot /cm/images/login-image /bin/bash

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -38,15 +38,6 @@
     - home
     - CRI_XCBC
 
-- name: clone chname to allow chroot env to be created with a desired hostname.
-  command: git clone https://github.com/4the1appdevs/chname.git /cm/shared/apps/chname
-
-- name: Install chname to allow chroot env to be created with a desired hostname.
-  command: make -C /cm/shared/apps/chname install 
-
-- name: Enter chroot env for login image with hostname OOD
-  command: chname ood chroot /cm/images/login-image /bin/bash
-
 ## preparation for ood_user_reg
 #- name: Install Copr plugin for yum
 #  yum: name=yum-plugin-copr state=present update_cache=true

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -49,7 +49,7 @@
 #  when: enable_copr == true and inventory_hostname in item.host
 
 - name: Run the Ansible roles related to login image
-  command: ansible-playbook -c local -i /CRI_XCBC/hosts -l `hostname -s` /CRI_XCBC/site-build.yaml -b -t {{ item }}
+  command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-build.yaml -b -t {{ item }}
   loop:
     - ood
     - ood_jupyter
@@ -62,7 +62,7 @@
     - ood_user_reg_cloud
 
 - name: Run the Ansible role related to self-reg
-  command: ansible-playbook -c local -i /CRI_XCBC/hosts -l `hostname -s` /CRI_XCBC/site-ops.yaml -b -t ood_user_reg_ops
+  command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-ops.yaml -b -t ood_user_reg_ops
 
 - name: enable munge service in login image chroot env
   command: systemctl enable munge.service

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -6,6 +6,9 @@
 - name: create a new node category for the image, called login
   command: cmsh -c "category; clone default login; set softwareimage login-image; roles; assign login; commit --wait"
 
+- name: Change default gateway for the login category to access internet
+  command: cmsh -c "category; use login; set defaultgateway 192.168.200.254; commit"
+
 - name: Add software to the image
   command: yum -y --installroot=/cm/images/login-image install {{ item }}
   loop:

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -1,0 +1,121 @@
+---
+# cod login-image build 
+- name: clone the default image to build a login image
+  command: cmsh -c "softwareimage; clone default-image login-image; commit --wait"
+
+- name: create a new node category for the image, called login
+  command: cmsh -c "category; clone default login; set softwareimage login-image; roles; assign login; commit --wait"
+
+- name: Add software to the image
+  command: yum -y --installroot=/cm/images/login-image install {{ item }}
+  loop:
+    - ansible
+    - git
+    - rh-git29
+    - vim
+    - bash-completion
+    - python3
+    - python3-devel
+    - shorewall
+    - nfs-utils
+
+#- name: Clone the prod CRI_XCBC ansible scripts to the chroot location
+#  git: 
+#    repo: https://github.com/uabrc/CRI_XCBC.git #{{ prod_CRI_XCBC_repo }} 
+#    dest: /cm/images/login-image/prod_CRI_XCBC  #{{ prod_CRI_XCBC_path }}
+#    version: {{ prod_CRI_XCBC_version }}
+
+- name: Clone the dev CRI_XCBC ansible scripts to the chroot location
+  git: 
+    repo: https://github.com/jprorama/CRI_XCBC.git
+    dest: /cm/images/login-image/CRI_XCBC
+    version: {{ CRI_XCBC_version }}
+
+- name: Create a symlink for munge.key before enabling munge service
+  command: ln -s /cm/shared/apps/slurm/var/munge/keys/munge.key /cm/images/login-image/etc/munge/munge.key
+
+- name: Mount dirs required for ansible scripts to function
+  command: mount -o bind /{{ item }} /cm/images/login-image/{{ item }}
+  loop:
+    - dev
+    - proc
+    - sys
+    - home
+
+- name: clone chname to allow chroot env to be created with a desired hostname.
+  command: git clone https://github.com/4the1appdevs/chname.git /cm/shared/apps/chname
+
+- name: Install chname to allow chroot env to be created with a desired hostname.
+  command: cd /cm/shared/apps/chname && make install
+
+- name: Enter chroot env for login image with hostname OOD
+  command: chname ood chroot /cm/images/login-image /bin/bash
+
+## preparation for ood_user_reg
+#- name: Install Copr plugin for yum
+#  yum: name=yum-plugin-copr state=present update_cache=true
+#  when: enable_copr == true
+#
+#- name: enable Copr Repos
+#  shell: yum -y copr enable "{{ item.repo_name }}"
+#  with_items: "{{ copr_repos }}"
+#  when: enable_copr == true and inventory_hostname in item.host
+
+- name: Run the Ansible roles related to login image
+  command: ansible-playbook -c local -i /CRI_XCBC/hosts -l `hostname -s` /CRI_XCBC/site-build.yaml -b -t {{ item }}
+  loop:
+    - ood
+    - ood_jupyter
+    - ood_vnc_form
+    - ood_add_rstudio
+    - ood_matlab
+    - ood_sas
+    - ood_firewall_and_services
+    - ood_shib_sso
+    - ood_user_reg_cloud
+
+- name: Run the Ansible role related to self-reg
+  command: ansible-playbook -c local -i /CRI_XCBC/hosts -l `hostname -s` /CRI_XCBC/site-ops.yaml -b -t ood_user_reg_ops
+
+- name: enable munge service in login image chroot env
+  command: systemctl enable munge.service
+
+- name: Exit chroot env for login image
+  command: exit
+
+# cod login node deploy
+- name: Change login001 category to login
+  command: cmsh -c "device; use login001; set category login; commit"
+
+- name: Set DHCP on BOOTIF device
+  command: cmsh -c "device; use login001; interfaces; use bootif; set dhcp yes; commit"
+
+#- name: Add an extra interface to login from externalnet
+#  command: cmsh -c "device; use login001; addinterface -c login physical eth1 externalnet 192.168.200.1; commit"
+
+#- name: Set DHCP on the new interface added above
+#  command: cmsh -c "device; use login001; interfaces; use eth1; set dhcp yes; commit"
+
+## Non-provisioning interfaces are inactive unless they are explicitly brought up
+#- name: Set external interface eth1 to come up during install.
+#  command: cmsh -c "device; use login001; interfaces; use eth1; set BringUpDuringInstall yes; commit"
+
+- name: Make sure tftp systemd service is running on head node
+  systemd:
+    state: started
+    name: tftpd
+
+# Port security is not enabled on internal ports, by default from Heat template
+# So this step and the next would not be necessary.
+#- name: Get BOOTIF interface ID in openstack
+#  command: openstack port list | grep -w "login001_internal_port" | awk '{ print $2 }'
+#  register: eth0_id
+#
+#- name: Remove port security
+#  command: openstack port set {{ eth0_id }} {{ item }}
+#  loop:
+#    - --no-security-group
+#    - --disable-port-security
+
+- name: Reboot login001 to pick up the new image
+  command: cmsh -c "device; use login001; reboot"

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -51,9 +51,6 @@
 - name: Run the Ansible roles related to login image
   command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-cod.yaml -b
 
-- name: Run the Ansible role related to self-reg
-  command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-ops.yaml -b -t ood_user_reg_ops
-
 - name: enable munge service in login image chroot env
   command: systemctl enable munge.service
 

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -18,20 +18,16 @@
     - shorewall
     - nfs-utils
 
-#- name: Clone the prod CRI_XCBC ansible scripts to the chroot location
-#  git: 
-#    repo: https://github.com/uabrc/CRI_XCBC.git #{{ prod_CRI_XCBC_repo }} 
-#    dest: /cm/images/login-image/prod_CRI_XCBC  #{{ prod_CRI_XCBC_path }}
-#    version: {{ prod_CRI_XCBC_version }}
-
-- name: Clone the dev CRI_XCBC ansible scripts to the chroot location
-  git: 
-    repo: https://github.com/jprorama/CRI_XCBC.git
-    dest: /cm/images/login-image/CRI_XCBC
-    version: {{ CRI_XCBC_version }}
-
 - name: Create a symlink for munge.key before enabling munge service
   command: ln -s /cm/shared/apps/slurm/var/munge/keys/munge.key /cm/images/login-image/etc/munge/munge.key
+
+- name: Create a directory for CRI_XCBC in the login-image chroot path
+  file:
+    path: "{{ bright_cod_login_chroot_loc }}/CRI_XCBC"
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
 
 - name: Mount dirs required for ansible scripts to function
   command: mount -o bind /{{ item }} /cm/images/login-image/{{ item }}
@@ -40,6 +36,7 @@
     - proc
     - sys
     - home
+    - CRI_XCBC
 
 - name: clone chname to allow chroot env to be created with a desired hostname.
   command: git clone https://github.com/4the1appdevs/chname.git /cm/shared/apps/chname

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -67,9 +67,6 @@
 - name: enable munge service in login image chroot env
   command: systemctl enable munge.service
 
-- name: Exit chroot env for login image
-  command: exit
-
 # cod login node deploy
 - name: Change login001 category to login
   command: cmsh -c "device; use login001; set category login; commit"

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -51,9 +51,6 @@
 - name: Run the Ansible roles related to login image
   command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-cod.yaml -b
 
-- name: enable munge service in login image chroot env
-  command: systemctl enable munge.service
-
 # cod login node deploy
 - name: Change login001 category to login
   command: cmsh -c "device; use login001; set category login; commit"

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -38,16 +38,6 @@
     - home
     - CRI_XCBC
 
-## preparation for ood_user_reg
-#- name: Install Copr plugin for yum
-#  yum: name=yum-plugin-copr state=present update_cache=true
-#  when: enable_copr == true
-#
-#- name: enable Copr Repos
-#  shell: yum -y copr enable "{{ item.repo_name }}"
-#  with_items: "{{ copr_repos }}"
-#  when: enable_copr == true and inventory_hostname in item.host
-
 - name: Run the Ansible roles related to login image
   command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-cod.yaml -b
 
@@ -63,10 +53,6 @@
 
 - name: Set DHCP on the new interface added above
   command: cmsh -c "device; use login001; interfaces; use eth1; set dhcp yes; commit"
-
-## Non-provisioning interfaces are inactive unless they are explicitly brought up
-#- name: Set external interface eth1 to come up during install.
-#  command: cmsh -c "device; use login001; interfaces; use eth1; set BringUpDuringInstall yes; commit"
 
 - name: Make sure tftp systemd service is running on head node
   systemd:

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -49,17 +49,7 @@
 #  when: enable_copr == true and inventory_hostname in item.host
 
 - name: Run the Ansible roles related to login image
-  command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-build.yaml -b -t {{ item }}
-  loop:
-    - ood
-    - ood_jupyter
-    - ood_vnc_form
-    - ood_add_rstudio
-    - ood_matlab
-    - ood_sas
-    - ood_firewall_and_services
-    - ood_shib_sso
-    - ood_user_reg_cloud
+  command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-cod.yaml -b
 
 - name: Run the Ansible role related to self-reg
   command: ansible-playbook -c chroot -i '/cm/images/login-image/CRI_XCBC/hosts' /CRI_XCBC/ood-ops.yaml -b -t ood_user_reg_ops

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -11,7 +11,6 @@
   loop:
     - ansible
     - git
-    - rh-git29
     - vim
     - bash-completion
     - python3


### PR DESCRIPTION
This PR contains the roles to build and deploy a login image with OOD and self-reg app on the head node of a Bright virtual cluster called Cluster on Demand.