### PR TITLE
Patch fix ood firewall and services role

### DIFF
--- a/roles/ood_firewall_and_services/tasks/main.yaml
+++ b/roles/ood_firewall_and_services/tasks/main.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Enable http service
   systemd:
-    state: started
     name: httpd24-httpd
     enabled: yes
 

--- a/roles/ood_firewall_and_services/tasks/main.yaml
+++ b/roles/ood_firewall_and_services/tasks/main.yaml
@@ -31,4 +31,5 @@
     state: permissive
 
 - name: Set SELinux to permissive mode without reboot
-  command: setenforce 0
+  selinux:
+    state: disabled


### PR DESCRIPTION

1. Removes unnecessary start of httpd24-httpd service during build OOD build where just enabling the services would suffice. Services can be started or restarted in ops phase i.e. post-deploy.
2. Use selinux ansible module so that the task is idempotent and it would not error out if selinux is already disabled.
