### PR TITLE
Fix service start during login image build

### DIFF
--- a/roles/ohpc_firewall_and_services/tasks/main.yaml
+++ b/roles/ohpc_firewall_and_services/tasks/main.yaml
@@ -1,6 +1,5 @@
 ---
-- name: start and enable munge
+- name: enable munge
   service:
     name: munge
-    state: started
     enabled: yes

--- a/roles/ohpc_firewall_and_services/tasks/main.yaml
+++ b/roles/ohpc_firewall_and_services/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
 - name: enable munge
-  service:
+  systemd:
     name: munge
     enabled: yes


### PR DESCRIPTION
1. Just enable service in `ohpc_firewall_and_services` role rather than starting them. It is not required in build stage.
These services should be started after build stage in ops phase.

2. Also use systemd module as recommended by ansible rather than a more generic services module.