### PR TITLE
Fix new rmq dir structure deploy

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -181,7 +181,6 @@
   rabbitmq_agents_repo: "https://github.com/uabrc/rabbitmq_agents.git"
   rabbitmq_agents_version: "feat-cod-rmq"
   rabbitmq_agents_service_user: "root"
-  cod_deploy: false
   
   # rabbit_config
   mail_server: "localhost"

--- a/roles/ohpc_add_rabbitmq_agents/tasks/main.yaml
+++ b/roles/ohpc_add_rabbitmq_agents/tasks/main.yaml
@@ -5,10 +5,23 @@
     dest: "{{ rabbitmq_agents_loc }}"
     version: "{{ rabbitmq_agents_version }}"
 
+- name: Create .agent_db dir for sqlite DB if not present
+  file:
+    path: "{{ rabbitmq_agents_loc }}/prod_rmq_agents/.agent_db"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
 - name: Install rabbitmq agents config file
   template:
     src: config.j2
     dest: "{{ rabbitmq_agents_loc }}/rabbit_config.py"
+
+- name: Install mail template as mail_config file
+  template:
+    src: mail_config.j2
+    dest: "{{ rabbitmq_agents_loc }}/mail_config.py"
 
 - name: Setup the venv for rabbitmq agents
   pip:
@@ -61,71 +74,4 @@
     enabled: yes
   loop: "{{ lookup('fileglob', '{{ rabbitmq_agents_loc }}/prod_rmq_agents/*.py', wantlist=True) }}"
   when: cod_deploy | bool
-=======
 
-- name: Install rabbitmq agents config file
-  template:
-    src: config.j2
-    dest: "{{ rabbitmq_agents_loc }}/rabbit_config.py"
-
-
-- name: Install mail template as mail_config file
-  template:
-    src: mail_config.j2
-    dest: "{{ rabbitmq_agents_loc }}/mail_config.py"
-
-
-- name: Setup the venv for rabbitmq agents
-  pip:
-    requirements: requirements.txt
-    virtualenv: venv
-    virtualenv_command: /usr/bin/python3 -m venv
-    chdir: "{{ rabbitmq_agents_loc }}"
-
-- name: Install agents as service
-  template:
-    src: agent.j2
-    dest: "/etc/systemd/system/{{ item.name }}_agent.service"
-  loop:
-    - { name: "ohpc_account", desc: "Service to create an account on OHPC" }
-    - { name: "slurm_account", desc: "Service to create a SLURM user and account" }
-    - { name: "get-next-uid-gid", desc: "Service to create a bright user account" }
-    - { name: "dir_verify", desc: "Service to verify directories are created" }
-    - { name: "git_commit", desc: "Service to commit new user ldap files to git" }
-    - { name: "subscribe_mail_lists", desc: "Service to subscribe the users to mailing list" }
-    - { name: "notify_user", desc: "Service to notify user about successful account creation" }
-    - { name: "task_manager", desc: "Service to manage message flow between above rabbitmq agents" }
-    - { name: "user_reg_logger", desc: "Service to store the request object passed during account request" }
-    - { name: "user_reg_event_logger", desc: "Service to log all messages passed during the account creation" }
-
-- name: Add Vhost in RabbitMQ
-  rabbitmq_vhost:
-    name: "{{ rabbitmq_vhost }}"
-    state: present
-
-- name: Add User in RabbitMQ
-  rabbitmq_user:
-    user: "{{ rabbitmq_user }}"
-    password: "{{ rabbitmq_user_password }}"
-    vhost: "{{ rabbitmq_vhost }}"
-    configure_priv: .*
-    read_priv: .*
-    write_priv: .*
-    state: present
-
-- name: Start and enable agent services
-  service:
-    name: "{{ item }}.service"
-    state: started
-    enabled: yes
-  loop:
-    - ohpc_account_agent
-    - slurm_account_agent
-    - get-next-uid-gid_agent
-    - dir_verify_agent
-    - git_commit_agent
-    - subscribe_mail_lists_agent
-    - notify_user_agent
-    - task_manager_agent
-    - user_reg_logger_agent
-    - user_reg_event_logger_agent

--- a/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
@@ -12,9 +12,6 @@ WorkingDirectory={{ item | dirname }}
 Environment="PYTHONPATH={{ rabbitmq_agents_loc }}"
 Environment="PATH={{ rabbitmq_agents_loc }}/venv/bin:{{ lookup('env','PATH') }}"
 ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python {{ item | basename | splitext | first }}.py
-WorkingDirectory={{ rabbitmq_agents_loc }}
-Environment="PATH={{ rabbitmq_agents_loc }}/venv/bin:{{ lookup('env','PATH') }}"
-ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python {{ item.name }}.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Add task to create a .agent_db dir for the rmq agent services
- Fix duplicate tasks in ohpc_add_rabbitmq_agents role
- Fix duplicate config values in service file template agent.j2
- Remove duplicate cod_deploy flag in group_vars/all