### PR TITLE
Fix cod rabbitmq

### DIFF
--- a/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
+++ b/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
@@ -2,11 +2,8 @@
 - name: Change the default min UID and GID to replicate prod
   replace:
     path: /etc/login.defs
-    regexp: "{{ item.regexp }}"
-    replace: "{{ item.line }}"
-  loop:
-    - { regexp: '^UID_MIN\s*1000', line: 'UID_MIN\t\t\t10000' }
-    - { regexp: '^GID_MIN\s*1000', line: 'GID_MIN\t\t\t10000' }
+    regexp: '^((U|G)ID_MIN)\s*1000$'
+    replace: '\1\t\t\t10000'
 
 - name: Create a user with id 10000
   command: cmsh -c "user; add test1; set id 10001; set email test1@localhost; set commonname test1; commit"

--- a/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
+++ b/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
@@ -1,4 +1,20 @@
 ---
+- name: Clone the repo where user ldap files are recorded
+  git:
+    repo: "{{ rc_users_ldap_repo }}"
+    dest: "{{ rc_users_ldap_repo_loc }}"
+  ignore_errors: yes
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+  when: result.failed == 'true' or result.rc is defined
+
+- name: "Action needed:"
+  fail:
+    msg: "You need to upload the ssh key to {{ rc_users_ldap_repo }}"
+  when:  result.failed == 'true' or result.rc is defined
+
 - name: Change the default min UID and GID to replicate prod
   replace:
     path: /etc/login.defs
@@ -16,20 +32,4 @@
     owner: root
     group: root
     mode: '0755'
-
-- name: Clone the repo where user ldap files are recorded
-  git:
-    repo: "{{ rc_users_ldap_repo }}"
-    dest: "{{ rc_users_ldap_repo_loc }}"
-  ignore_errors: yes 
-  register: result
-
-- debug:
-    msg: "{{ result }}"
-  when: result.failed == 'true' or result.rc is defined
-
-- name: "Action needed:"
-  fail:
-    msg: "You need to upload the ssh key to {{ rc_users_ldap_repo }}"
-  when:  result.failed == 'true' or result.rc is defined
 

--- a/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
+++ b/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
@@ -6,8 +6,9 @@
   ignore_errors: yes
   register: result
 
-- debug:
-    msg: "{{ result }}"
+- name: Error message
+  debug:
+    msg: "{{ result.stderr_lines }}"
   when: result.failed == 'true' or result.rc is defined
 
 - name: "Action needed:"


### PR DESCRIPTION
Move git clone task to the beginning, to prevent other tasks being executed more than once when error occurs. 
Modify the regexp used in updating `/etc/login.defs`, to prevent the number increased more than once.