### PR TITLE
Fix rabbitmq bintray repo

### DIFF
--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -40,6 +40,13 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: 300
 
+- name: Install necessary packages
+  yum:
+    state: latest
+    name:
+      - socat
+      - logrotate
+
 - name: Install Erlang
   yum:
     name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.3.4.2-1.el7.x86_64.rpm

--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -6,7 +6,11 @@
 - name: Import RabbitMQ signing key
   rpm_key:
     state: present
-    key: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+    key: "{{ item }}"
+  loop:
+    - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
+    - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
+    - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
 
 - name: Add RabbitMQ bintray repository
   yum_repository:

--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -27,6 +27,19 @@
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
     metadata_expire: 300
 
+- name: Add Rabbitmq server repository
+  yum_repository:
+    name: rabbitmq_server
+    description: Rabbitmq Server (CentOS 7)
+    baseurl: https://packagecloud.io/rabbitmq/rabbitmq-server/el/7/$basearch
+    repo_gpgcheck: yes
+    gpgcheck: yes
+    enabled: yes
+    gpgkey: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
+    sslverify: yes
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    metadata_expire: 300
+
 - name: Install Erlang
   yum:
     name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.3.4.2-1.el7.x86_64.rpm

--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -12,13 +12,20 @@
     - "https://packagecloud.io/rabbitmq/erlang/gpgkey"
     - "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
 
-- name: Add RabbitMQ bintray repository
+- name: Add Erlang repository
   yum_repository:
-    name: bintray-rabbitmq-rpm
-    description: RabbitMQ (CentOS 7)
-    baseurl: https://dl.bintray.com/rabbitmq/rpm/rabbitmq-server/v3.8.x/el/7/
-    gpgcheck: no
+    name: rabbitmq_erlang
+    description: Erlang (CentOS 7)
+    baseurl: https://packagecloud.io/rabbitmq/erlang/el/7/$basearch
+    repo_gpgcheck: yes
+    gpgcheck: yes
     enabled: yes
+    gpgkey:
+      - https://packagecloud.io/rabbitmq/erlang/gpgkey
+      - https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+    sslverify: yes
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    metadata_expire: 300
 
 - name: Install Erlang
   yum:

--- a/roles/ohpc_rabbitmq/tasks/main.yaml
+++ b/roles/ohpc_rabbitmq/tasks/main.yaml
@@ -49,13 +49,15 @@
 
 - name: Install Erlang
   yum:
-    name: https://bintray.com/rabbitmq-erlang/rpm/download_file?file_path=erlang%2F22%2Fel%2F7%2Fx86_64%2Ferlang-22.3.4.2-1.el7.x86_64.rpm
-    state: present
+    name: erlang
+    enablerepo: rabbitmq_erlang
+    state: latest
 
 - name: Install RabbitMQ Server
   yum:
     name: rabbitmq-server
-    state: present
+    enablerepo: rabbitmq_server
+    state: latest
 
 - name: Start and enable RabbitMQ Server
   service:


### PR DESCRIPTION
Since bintray is shutting down, we update the yum repository for rabbitmq server according the document provided by Rabbitmq team. [LINK](https://www.rabbitmq.com/install-rpm.html)