### PR TITLE
Fix user reg config without shib

### DIFF
--- a/roles/ood_user_reg_cloud/tasks/main.yml
+++ b/roles/ood_user_reg_cloud/tasks/main.yml
@@ -65,6 +65,13 @@
   template:
     src: user-reg_conf_shib.j2
     dest: "/opt/rh/httpd24/root/etc/httpd/conf.d/user-reg.conf"
+  when: enable_shib
+
+- name: Put apache config file in place (user-reg_conf_shib.j2 in case of shib or user-reg_conf.j2 in case of basicauth)
+  template:
+    src: user-reg_conf.j2
+    dest: "/opt/rh/httpd24/root/etc/httpd/conf.d/user-reg.conf"
+  when: not enable_shib
 
 - name: Put gunicorn config file in place
   template:


### PR DESCRIPTION
Now the role uses the same user-reg config file with or without shib deploy.
There's setting only meant for shib in one of the config file and will cause error if no shib is installed.