### PR TITLE
Feat module usage tracking

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -210,3 +210,12 @@
 
 #ClusteronDemand CoD
   cod_deploy: true
+
+# Lmod
+  lmod_loc: "/opt/ohpc/admin/lmod/lmod"
+  lmod_archive_loc: "{{ cluster_shared_folder }}/rc/lmod"
+  lmod_module_tracking_loc: "{{ lmod_loc }}/tools/tracking_module_usage"
+  lmod_db: "lmod"
+  lmod_db_user: "lmod"
+  lmod_db_passwd: "password"
+  lmod_db_host: "ohpc"

--- a/group_vars/all
+++ b/group_vars/all
@@ -218,4 +218,4 @@
   lmod_db: "lmod"
   lmod_db_user: "lmod"
   lmod_db_passwd: "password"
-  lmod_db_host: "ohpc"
+  lmod_db_host_machine: "ohpc"

--- a/roles/lmod_db/files/SitePackage.lua
+++ b/roles/lmod_db/files/SitePackage.lua
@@ -1,0 +1,44 @@
+--------------------------------------------------------------------------
+-- load_hook(): Here we record the any modules loaded.
+
+local hook    = require("Hook")
+local uname   = require("posix").uname
+local cosmic  = require("Cosmic"):singleton()
+local syshost = cosmic:value("LMOD_SYSHOST")
+
+local s_msgA = {}
+
+local function load_hook(t)
+   -- the arg t is a table:
+   --     t.modFullName:  the module full name: (i.e: gcc/4.7.2)
+   --     t.fn:           The file name: (i.e /apps/modulefiles/Core/gcc/4.7.2.lua)
+
+
+   -- use syshost from configuration if set
+   -- otherwise extract 2nd name from hostname: i.e. login1.stampede2.tacc.utexas.edu
+   local host        = syshost
+   if (not host) then
+      local i,j, first
+      i,j, first, host = uname("%n"):find("([^.]*)%.([^.]*)%.")
+   end
+
+
+   if (mode() ~= "load") then return end
+   local msg         = string.format("user=%s module=%s path=%s host=%s time=%f",
+                                     os.getenv("USER"), t.modFullName, t.fn, uname("%n"),
+                                     epoch())
+   local a           = s_msgA
+   a[#a+1]           = msg
+end
+
+hook.register("load", load_hook)
+
+local function report_loads()
+   local a = s_msgA
+   for i = 1,#a do
+      local msg = a[i]
+      lmod_system_execute("logger -t ModuleUsageTracking -p local0.info " .. msg)
+   end
+end
+
+ExitHookA.register(report_loads)

--- a/roles/lmod_db/files/moduleTracking.conf
+++ b/roles/lmod_db/files/moduleTracking.conf
@@ -1,0 +1,8 @@
+$Ruleset remote
+if $programname contains 'ModuleUsageTracking' then /var/log/moduleUsage.log
+$Ruleset RSYSLOG_DefaultRuleset
+
+# provides UDP syslog reception
+$ModLoad imudp
+$InputUDPServerBindRuleset remote
+$UDPServerRun 514

--- a/roles/lmod_db/files/moduleUsage
+++ b/roles/lmod_db/files/moduleUsage
@@ -1,0 +1,8 @@
+/var/log/moduleUsage.log{
+   missingok
+   copytruncate
+   rotate 4
+   daily
+   create 644 root root
+   notifempty
+}

--- a/roles/lmod_db/tasks/main.yaml
+++ b/roles/lmod_db/tasks/main.yaml
@@ -1,0 +1,99 @@
+---
+- name: Install necessary packages
+  yum:
+    state: present
+    name: mariadb
+
+- name: Install necessary packages
+  pip:
+    state: present
+    name: mysql-python
+
+- name: Install necessary packages
+  pip:
+    state: present
+    name: mysqlclient
+    executable: pip3
+
+- name: Update SitePackge.lua
+  copy:
+    src: SitePackage.lua
+    dest: "{{ lmod_loc }}/libexec/SitePackage.lua"
+
+- name: Import file in warewulf
+  import_tasks: warewulf_steps.yaml
+  when: not cod_deploy
+
+- name: Clone Lmod repo
+  git:
+    repo: https://github.com/TACC/Lmod.git
+    dest: /tmp/lmod
+
+- name: Copy module tracking folder
+  copy:
+    src: /tmp/lmod/contrib/tracking_module_usage/
+    dest: "{{ lmod_module_tracking_loc }}"
+    remote_src: yes
+
+- name: Remove lmod repo
+  file:
+    path: /tmp/lmod
+    state: absent
+
+- name: Create module archive directory
+  file:
+    path: "{{ lmod_archive_loc }}"
+    state: directory
+
+- name: Update rsyslog.d
+  lineinfile:
+    path: /etc/rsyslog.conf
+    line: '\$IncludeConfig /etc/rsyslog.d/\*.conf)'
+    backup: yes
+
+- name: Put rsyslog config file in place
+  copy:
+    src: moduleTracking.conf
+    dest: /etc/rsyslog.d/moduleTracking.conf
+
+- name: Set up log rotate for module usage
+  copy:
+    src: moduleUsage
+    dest: /etc/logrotate.d/moduleUsage
+
+- name: Set up module tracking database user
+  mysql_user:
+    name: "{{ lmod_db_user }}"
+    password: "{{ lmod_db_passwd }}"
+    priv: "{{ lmod_db }}.*:ALL"
+    state: present
+
+- name: Setup config file for module tracking
+  command: ./conf_create --dbhost="localhost" --dbuser="{{ lmod_db_user }}" --passwd="{{ lmod_db_passwd }}" --dbname="{{ lmod_db }}"
+  args:
+    chdir: "{{ lmod_module_tracking_loc }}"
+
+- name: Setup database
+  command: ./createDB.py
+  args:
+    chdir: "{{ lmod_module_tracking_loc }}"
+
+- name: Modify store db script
+  lineinfile:
+    path: "{{ lmod_module_tracking_loc }}/store_module_data"
+    line: "    dataT['syshost'] = syshost(dataT['host'])"
+    state: absent
+    backup: yes
+
+- name: Setup cron job script
+  template:
+    src: cron.j2
+    dest: /etc/cron.daily/module_to_db
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/lmod_db/tasks/warewulf_steps.yaml
+++ b/roles/lmod_db/tasks/warewulf_steps.yaml
@@ -1,0 +1,13 @@
+---
+- name: Get node list
+  command: "wwsh node list -1"
+  ignore_errors: yes
+  register: node_list
+
+- name: Add SitePackage.lua to warewulf database
+  command: "wwsh file import {{ lmod_loc }}/libexec/SitePackage.lua"
+
+- name: Add file for provision
+  command: "wwsh -y provision set {{ item }} --fileadd=SitePackage.lua"
+  loop: "{{ node_list.stdout_lines | map('trim') | list }}"
+

--- a/roles/lmod_db/templates/cron.j2
+++ b/roles/lmod_db/templates/cron.j2
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd {{ lmod_module_tracking_loc }}
+
+for i in /var/log/moduleUsage.log-*; do
+  ./store_module_data $i
+  if [ "$?" -eq 0 ]; then
+    mv $i {{ lmod_archive_loc }}
+  fi
+done

--- a/roles/lmod_user/tasks/main.yaml
+++ b/roles/lmod_user/tasks/main.yaml
@@ -1,0 +1,10 @@
+---
+- name: Setup rsyslog
+  template:
+    src: rsyslog.j2
+    dest: /etc/rsyslog.d/
+
+- name: Restart rsyslog
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/lmod_user/templates/rsyslog.j2
+++ b/roles/lmod_user/templates/rsyslog.j2
@@ -1,0 +1,2 @@
+if $programname contains 'ModuleUsageTracking' then @{{ lmod_db_host_machine }}
+&~


### PR DESCRIPTION
Add module usage tracking feature into cluster.

`lmod_db` role will be run on master, where MySQL is installed.
`lmod_user` role will be run on all other nodes, e.g. compute nodes and login nodes.