### PR TITLE
added rewritecond to parse the REMOTE_USER value

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -11,7 +11,9 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
         AuthType shibboleth
         ShibRequestSetting requireSession 1
         Require valid-user
-        RequestHeader set REMOTE_USER expr=%{REMOTE_USER}
+        RewriteCond %{IS_SUBREQ} ^false$
+        RewriteCond %{LA-U:REMOTE_USER} "^([a-z]+)@samltest.id$"
+        RequestHeader set REMOTE_USER %{RU}e
         RewriteCond %{IS_SUBREQ} ^false$
         RewriteCond %{LA-U:displayName} (.+)
         RewriteRule . - [E=displayName:%1]


### PR DESCRIPTION
The conditions are specific to samltest values
Example: REMOTE_USER value provided by SAML is msmith@samltest.id and would be parsed to msmith with the apache rewrite conditions