### PR TITLE
Fix ood shib sso role failed

### DIFF
--- a/roles/ood_shib_sso/tasks/main.yml
+++ b/roles/ood_shib_sso/tasks/main.yml
@@ -34,11 +34,6 @@
     src: shibboleth2.xml
     dest: /etc/shibboleth/shibboleth2.xml
 
-- name: add saml-to-ood user map file
-  copy:
-    src: ood-user-mapfile
-    dest: /etc/ood/ood-user-mapfile
-
 - name: update ood portal config with user mapfile
   replace:
     path: /etc/ood/config/ood_portal.yml


### PR DESCRIPTION
ood user map file has been deleted, but the task that copys the file to ood node is not.
This cause the ood deploy to fail.