### PR TITLE
Feat-shib-user-attributes-parser

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -16,9 +16,13 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
         RewriteRule . - [E=RU:%1]
         RequestHeader set REMOTE_USER %{RU}e
         RewriteCond %{IS_SUBREQ} ^false$
-        RewriteCond %{LA-U:displayName} (.+)
-        RewriteRule . - [E=displayName:%1]
-        RequestHeader set REMOTE_USER_DISPLAYNAME %{displayName}e
+        RewriteCond %{LA-U:givenName} (.+)
+        RewriteRule . - [E=givenName:%1]
+        RewriteCond %{IS_SUBREQ} ^false$
+        RewriteCond %{LA-U:sn} (.+)
+        RewriteRule . - [E=sn:%1]
+        SetEnv space " "
+        RequestHeader set REMOTE_USER_DISPLAYNAME %{givenName}e%{space}e%{sn}e        
         RewriteCond %{IS_SUBREQ} ^false$
         RewriteCond %{LA-U:mail} (.+)
         RewriteRule . - [E=mail:%1]


### PR DESCRIPTION
The conditions are specific to samltest values

1. parse REMOTE_USER 
 -  REMOTE_USER value provided by SAML is msmith@samltest.id and would be parsed to "msmith" with the apache rewrite conditions
2. parse value displayname as givenName (firstname) + " "(space) + sn (surname/last name)
