### PR TITLE
fix selfreg user not found issue

### DIFF
--- a/ood-cod.yaml
+++ b/ood-cod.yaml
@@ -10,5 +10,5 @@
     - { name: 'ood_firewall_and_services', tags: 'ood_firewall_and_services' }
     - { name: 'ohpc_firewall_and_services', tags: 'ohpc_firewall_and_services' }
     - { name: 'ood_shib_sso', tags: 'ood_shib_sso', when: enable_shib }
-    - { name: 'ood_user_reg_cloud', tags: 'ood_user_reg_cloud' }
     - { name: 'ood_user_reg_ops', tags: 'ood_user_reg_ops' }
+    - { name: 'ood_user_reg_cloud', tags: 'ood_user_reg_cloud' }


### PR DESCRIPTION
Issue: Selfreg user not found error on login node while running ood_user_reg_cloud role
Fix: run the ops role (which creates the user on login node) prior to running the app role