### PR TITLE
fix cors allowed values to all entries

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -163,7 +163,7 @@
   user_register_app_path: "/var/www/ood/register/{{ user_register_app }}"
   user_register_app_key: "1234"
   user_register_app_repo: "https://gitlab.rc.uab.edu/rc/self-reg-form.git"
-  cors_allowed_origins: "https://testshib.dev.rc.uab.edu"
+  cors_allowed_origins: "*"
   mod_wsgi_pkg_name: "uab-httpd24-mod_wsgi"
   RegUser_app_user: "reggie"
   RegUser_app_user_full_name: "RegUser of user register app"


### PR DESCRIPTION
This variable can be set more specific to the domain name given to the login node

example:
if /etc/hosts value for login node is set to https://testshib.dev.rc.uab.edu
cors_allowed_origins: "https://testshib.dev.rc.uab.edu"