### PR TITLE
fixed apache template file typo

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user-reg_conf.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf.j2
@@ -9,7 +9,7 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
 
 <Location /register>
         AuthType Basic
-        AuthName "Private"
+        AuthName "private"
         AuthUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd"
         RequestHeader unset Authorization
         Require valid-user
@@ -17,7 +17,7 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
 
 <Location "/static/">
         AuthType Basic
-        AuthName "Private"
+        AuthName "private"
         AuthUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd"
         RequestHeader unset Authorization
         Require valid-user


### PR DESCRIPTION
Issue: was prompted to enter login details twice due to 

'AuthName "private"' in ood_portal.yml but 'AuthName "Private"' in the user-reg template file