### PR TITLE
Add precise variables for ood

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -20,6 +20,8 @@
 
 #slurm.conf variables
   cluster_name: "ohpc"
+  cluster_title: "Ohpc Cluster"
+  cluster_host: "ohpc.local"
   slurm_bin_path: "/bin"
   slurm_conf_path: "/etc/slurm/slurm.conf"
 #  gres_types: "gpu"

--- a/roles/ood/templates/cluster.yml
+++ b/roles/ood/templates/cluster.yml
@@ -1,9 +1,10 @@
 ---
 v2:
   metadata:
-    title: "{{ cluster_name }}"
+    title: "{{ cluster_title }}"
   login:
-    host: "{{ cluster_name }}"
+    host: "{{ cluster_host }}"
+    default: true
   job:
     adapter: "slurm"
     bin: "{{ slurm_bin_path }}"


### PR DESCRIPTION
Add cluster_title, cluster_host for the cluster definition file.
Set cluster_host as default host for OOD.