### PR TITLE
Fixed Unknown lvalue  error seen in celery service file

### DIFF
--- a/roles/ood_user_reg_cloud/templates/celery.service.j2
+++ b/roles/ood_user_reg_cloud/templates/celery.service.j2
@@ -1,10 +1,10 @@
 [Unit]
 Description=Service to start celery process.
 After=network.target
-StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+StartLimitInterval=0
 Restart=always
 RestartSec=5
 User={{ celery_user }}


### PR DESCRIPTION
Added StartLimitInterval in section 'Service'
Removed StartLimitIntervalSec from section 'Unit'

Reference:
man systemd.service in our cod-cluster

Error:
Unknown lvalue 'StartLimitIntervalSec' in section 'Unit'