### PR TITLE
Fix blockinfile marker convention for auth block

### DIFF
--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -83,6 +83,7 @@
     path: /etc/ood/config/ood_portal.yml
     insertbefore: "#auth:"
     backup: yes
+    marker: "# {mark} ANSIBLE MANAGED BLOCK auth"
     block: |
       auth:
         - 'AuthType Basic'


### PR DESCRIPTION
blockinfile default auth for our CoD cluster is set to basic.