### PR TITLE
fix: Ondemand cert issue

### DIFF
--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -32,11 +32,13 @@
   yum:
     name: "{{ ood_rpm_repo }}"
     state: present
+    validate_certs: no
 
 - name: Install OnDemand and all of its dependencies
   yum:
     name: "ondemand"
     state: present
+    validate_certs: no
 
 - name: Create clusters.d directory
   file:


### PR DESCRIPTION
Resolved by adding validate_certs: false while downloading via yum

Issue seen: urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)>
Issue posted in OSC discourse https://discourse.openondemand.org/t/ondemand-cert-issue/1978