### PR TITLE
Fix: Shib restart issue seen in login node image build

### DIFF
--- a/roles/ood_shib_config/tasks/main.yaml
+++ b/roles/ood_shib_config/tasks/main.yaml
@@ -68,6 +68,4 @@
 - name: Restart shibd and enable on boot
   service:
     name: shibd
-    state: restarted
-    daemon_reload: yes
     enabled: yes


### PR DESCRIPTION
removed state restarted 
set  enabled: yes 