### PR TITLE
Restart cmd with new config

### DIFF
--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -108,6 +108,11 @@
     regexp: "^#? ?AdvancedConfig.*"
     replace: 'AdvancedConfig = { "AddUserScript=/root/bin/{{ post_create_script }}" }'
 
+- name: Restart cmd to pick up the change
+  systemd:
+    state: restarted
+    name: cmd
+
 - name: Make sure tftp systemd service is running on head node
   systemd:
     state: started


### PR DESCRIPTION
After putting post user creation script in place, and updating `cmd.conf` to point to the script, `cmd` needs to be restarted to pick up the change.