### PR TITLE
Move reboot login node task to before restart cmd

### DIFF
--- a/roles/cod_compute_node/tasks/main.yml
+++ b/roles/cod_compute_node/tasks/main.yml
@@ -60,11 +60,6 @@
   with_sequence: "start=1 count={{ num_compute_nodes }} format={{ compute_node_format }}"
   changed_when: True
 
-- name: Make sure tftp systemd service is running on head node
-  systemd:
-    state: started
-    name: tftpd
-
 - name: Reboot compute node to pick up the new image
   command: cmsh -c "device; use {{ item }}; reboot"
   with_sequence: "start=1 count={{ num_compute_nodes }} format={{ compute_node_format }}"

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -96,6 +96,11 @@
   with_sequence: "start=1 count={{ num_login_nodes }} format={{ login_node_format }}"
   changed_when: True
 
+- name: Reboot login001 to pick up the new image
+  command: cmsh -c "device; use {{ item }}; reboot"
+  with_sequence: "start=1 count={{ num_login_nodes }} format={{ login_node_format }}"
+  changed_when: True
+
 - name: Put post creation script in place
   template:
     src: PostAddUserScript.j2
@@ -117,8 +122,3 @@
   systemd:
     state: started
     name: tftpd
-
-- name: Reboot login001 to pick up the new image
-  command: cmsh -c "device; use {{ item }}; reboot"
-  with_sequence: "start=1 count={{ num_login_nodes }} format={{ login_node_format }}"
-  changed_when: True

--- a/roles/cod_login_node/tasks/main.yml
+++ b/roles/cod_login_node/tasks/main.yml
@@ -117,8 +117,3 @@
   systemd:
     state: restarted
     name: cmd
-
-- name: Make sure tftp systemd service is running on head node
-  systemd:
-    state: started
-    name: tftpd


### PR DESCRIPTION
Reboot the login node right after restarting `cmd` somehow causes rebooting process to fail.