### PR TITLE
Move StartLimitIntervalSec from Unit to Service in service files

### DIFF
--- a/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
@@ -1,9 +1,9 @@
 [Unit]
 After=rabbitmq-server.service
-StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+StartLimitInterval=0
 Restart=always
 RestartSec=1
 User={{ rabbitmq_agents_service_user }}

--- a/roles/ood_add_rabbitmq_agents/templates/ood_account_agent.j2
+++ b/roles/ood_add_rabbitmq_agents/templates/ood_account_agent.j2
@@ -1,10 +1,10 @@
 [Unit]
 Description=Service to create an account on OOD.
 After=network.target
-StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+StartLimitInterval=0
 Restart=always
 RestartSec=5
 User=centos


### PR DESCRIPTION
Also, rename the variable to StartLimitInterval

Source: https://dev.arvados.org/issues/12720
Service → StartLimitInterval (versions up to 219, incl. ubuntu:trusty)
Unit → StartLimitInterval (version 229, incl. ubuntu:xenial)
Unit → StartLimitIntervalSec (version 230+)

CoD is running systemd 219