### PR TITLE
Feat update rmq sysd service file

### DIFF
--- a/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=1
 User={{ rabbitmq_agents_service_user }}
 WorkingDirectory={{ item | dirname }}
-Environment="SLURMCONF={{ slurm_conf_path }}"
+Environment="SLURM_CONF={{ slurm_conf_path }}"
 Environment="PYTHONPATH={{ rabbitmq_agents_loc }}"
 Environment="PATH={{ rabbitmq_agents_loc }}/venv/bin:{{ lookup('env','PATH') }}"
 ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python -u {{ item | basename | splitext | first }}.py

--- a/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
@@ -8,6 +8,7 @@ Restart=always
 RestartSec=1
 User={{ rabbitmq_agents_service_user }}
 WorkingDirectory={{ item | dirname }}
+Environment="SLURMCONF={{ slurm_conf_path }}"
 Environment="PYTHONPATH={{ rabbitmq_agents_loc }}"
 Environment="PATH={{ rabbitmq_agents_loc }}/venv/bin:{{ lookup('env','PATH') }}"
 ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python -u {{ item | basename | splitext | first }}.py

--- a/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/agent.j2
@@ -10,7 +10,7 @@ User={{ rabbitmq_agents_service_user }}
 WorkingDirectory={{ item | dirname }}
 Environment="PYTHONPATH={{ rabbitmq_agents_loc }}"
 Environment="PATH={{ rabbitmq_agents_loc }}/venv/bin:{{ lookup('env','PATH') }}"
-ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python {{ item | basename | splitext | first }}.py
+ExecStart={{ rabbitmq_agents_loc }}/venv/bin/python -u {{ item | basename | splitext | first }}.py
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates the template file for RMQ sysd services 
1. To update the journal log for the unit immediately without buffering them. It helps us in logging the agent activities. 
2. Add slurm config path to the RMQ sysd services' env without which the agents running slurm commands wouldn't know the path for slurm config.