### PR TITLE
Fix cmsh cmd error with rc=2 in ansible

### DIFF
--- a/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
+++ b/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
@@ -36,7 +36,7 @@
     state: restarted
 
 - name: Create nossh group
-  command: module load cmsh && cmsh -c "group; add nossh; commit"
+  command: /cm/local/apps/cmd/bin/cmsh -c "group; add nossh; commit"
 
 - name: Add nossh group to denygroups
   lineinfile:


### PR DESCRIPTION
This PR fixes the ` "[Errno 2] No such file or directory"` issue while running cmsh command in ansible task.