### PR TITLE
Fix cmsh not load on CoD

### DIFF
--- a/roles/cod_module/files/DefaultModules.lua
+++ b/roles/cod_module/files/DefaultModules.lua
@@ -11,7 +11,7 @@ end
 local uid, status = chomp(capture("/usr/bin/id -u"))
 
 if uid == "0" then
-  try_load("shared", "cmd", "cluster-tools", "slurm/slurm")
+  try_load("shared", "cmd", "cluster-tools", "slurm/slurm", "cmsh")
 else
   try_load("shared", "slurm/slurm") -- DEFAULT_MODULES_OTHER
 end

--- a/roles/cod_module/files/DefaultModules.lua
+++ b/roles/cod_module/files/DefaultModules.lua
@@ -11,7 +11,7 @@ end
 local uid, status = chomp(capture("/usr/bin/id -u"))
 
 if uid == "0" then
-  load("shared", "cmd", "cluster-tools", "slurm/slurm")
+  try_load("shared", "cmd", "cluster-tools", "slurm/slurm")
 else
-  load("shared", "slurm/slurm") -- DEFAULT_MODULES_OTHER
+  try_load("shared", "slurm/slurm") -- DEFAULT_MODULES_OTHER
 end

--- a/roles/cod_module/tasks/main.yaml
+++ b/roles/cod_module/tasks/main.yaml
@@ -24,3 +24,9 @@
   loop:
     - "/usr/share/modulefiles"
     - "/cm/images/default-image/usr/share/modulefiles"
+
+- name: Update bashrc that load default modules for root
+  replace:
+    path: '/root/.bashrc'
+    regexp: '^#?\s?(module .*)$'
+    replace: '# \1'


### PR DESCRIPTION
I removed `cmsh` from `DefaultModules` before because there's no `cmsh` on the login node and that causes the `DefaultModules` not being loaded at all on the login node.
Using `try_load` instead, it loads the module if it exists, ignore it if not exist.