### PR TITLE
Use a var to define the user_map_cmd 

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -199,6 +199,7 @@
   user_register_app_refspec: "{{ gitlab_refspec }}"
   user_register_app_url: "/register"
   user_register_app_port: 8000
+  user_map_cmd_path: "/opt/ood/ood_auth_map/bin/user_auth.py"
   cors_allowed_origins: "*"
   mod_wsgi_pkg_name: "uab-httpd24-mod_wsgi"
   RegUser_app_user: "reggie"

--- a/roles/ood_user_reg_cloud/tasks/main.yml
+++ b/roles/ood_user_reg_cloud/tasks/main.yml
@@ -115,14 +115,14 @@
     replace: '{{ item.replace }}'
     backup: yes
   with_items:
-      - { regexp: "^#?(user_map_cmd:).*", replace: "\\1 '/opt/ood/ood_auth_map/bin/user_auth.py'" }
+      - { regexp: "^#?(user_map_cmd:).*", replace: "\\1 '{{ user_map_cmd_path }}'" }
       - { regexp: "^#?(map_fail_uri:).*", replace: "\\1 '{{ user_register_app_url }}'" }
       - { regexp: "^#?(register_uri:).*", replace: "\\1 '{{ user_register_app_url }}'" }
 
 - name: Stage regex file for ood
   template:
     src: user_auth_py.j2
-    dest: /opt/ood/ood_auth_map/bin/user_auth.py
+    dest: '{{ user_map_cmd_path }}'
     owner: root
     group: root
     mode: 0755


### PR DESCRIPTION
This PR will allow us to easily specify which user map command (user_auth.py or user_map_regex.rb) to be used via group_vars/all.