### PR TITLE
Fix regex deleted user

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user_auth_py.j2
+++ b/roles/ood_user_reg_cloud/templates/user_auth_py.j2
@@ -26,6 +26,15 @@ else:
     else:
         username = match.group(1)
 
+    # As a workaround for deleted user showing in user state db
+    # and being redirected to dashboard
+    rc = subprocess.run(
+        ["getent", "passwd", username], stdout=subprocess.DEVNULL
+    ).returncode
+    if rc != 0:
+        print()
+        sys.exit()
+
     # Check state from db
     result = rc_util.check_state(username)
 


### PR DESCRIPTION
We don't have `deleted` state right now. When deleting a user, we want to keep all state records but redirect them to the register page.
Before implementing delete user agent, put in a workaround by checking from `getent passwd` before checking user state agent.