### PR TITLE
Feat add ssh lock_groups rabbit_config

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -260,6 +260,10 @@
   rc_users_ldap_repo: "git@gitlab.rc.uab.edu:atlurie/rc-user-add-test.git"
   rc_users_ldap_repo_loc: "~/git/rc-users"
   valid_user_state: ['ok', 'hold', 'certification', 'pre_certification']
+  # dict values in lock_groups correspond to the states defined above
+  lock_groups: { "hold":"hold",
+                 "certification":"certify",
+                 "pre_certification":"pre_certify" }
   cmsh_version: 9.0
 
 # Celery

--- a/group_vars/all
+++ b/group_vars/all
@@ -294,9 +294,9 @@
 
 # ssh groups
   ssh_groups:
-    - {"name": "hold", "deny": true, "msg": "Your UAB Research Computing account is currently on hold. Accounts are put on hold if there are changes with UAB affiliation or if there is an issue on one of the platforms. Please reach out to support@listserv.uab.edu or attend the weekly office hours and we'll work with you to clear your account."}
-    - {"name": "certify", "deny": true, "msg": "Account certification required.  Please visit https://rc.uab.edu/account in order to continuing using this account."}
-    - {"name": "precertify", "deny": false, "msg": ""}
+    - {"name": "hold", "deny": true, "msg": "Your account is currently on hold. Please reach out to administrator to clear your account."}
+    - {"name": "certification", "deny": true, "msg": "Account certification is required. Please reach out to administrator to clear your account."}
+    - {"name": "pre_certification", "deny": false, "msg": ""}
 
 # refspec for merge/pull request
 # with refspec set up, you can specify version as:

--- a/group_vars/all
+++ b/group_vars/all
@@ -288,6 +288,12 @@
   lmod_db_allow_host: "localhost"
   lmod_db_host_machine: "ohpc"
 
+# ssh groups
+  ssh_groups:
+    - {"name": "hold", "deny": true, "msg": "Your UAB Research Computing account is currently on hold. Accounts are put on hold if there are changes with UAB affiliation or if there is an issue on one of the platforms. Please reach out to support@listserv.uab.edu or attend the weekly office hours and we'll work with you to clear your account."}
+    - {"name": "certify", "deny": true, "msg": "Account certification required.  Please visit https://rc.uab.edu/account in order to continuing using this account."}
+    - {"name": "precertify", "deny": false, "msg": ""}
+
 # refspec for merge/pull request
 # with refspec set up, you can specify version as:
 # gitlab: mr/MR_ID

--- a/roles/add_groups/handlers/main.yaml
+++ b/roles/add_groups/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: Restart sshd
+  systemd:
+    state: restarted
+    name: sshd

--- a/roles/add_groups/tasks/main.yaml
+++ b/roles/add_groups/tasks/main.yaml
@@ -1,0 +1,28 @@
+---
+- name: Create groups
+  command: /cm/local/apps/cmd/bin/cmsh -c "group; add {{ item.name }}; commit"
+  loop: "{{ ssh_groups }}"
+
+- name: Add default banner for users in deny groups
+  blockinfile:
+    path: /etc/ssh/sshd_config
+    marker: "# {mark} ANSIBLE added denygroup: {{ item.name }}"
+    backup: yes
+    block: |
+      DenyGroups {{ item.name }}
+      Match Group {{ item.name }}
+        Banner /etc/ssh/{{ item.name }}-msg
+        ForceCommand echo
+        PasswordAuthentication no
+      Match all
+  when: item.deny
+  loop: "{{ ssh_groups }}"
+
+- name: Create banner message file
+  copy:
+    content: "{{ item.msg }}"
+    dest: "/etc/ssh/{{ item.name }}-msg"
+    owner: root
+    group: root
+  when: item.msg
+  loop: "{{ ssh_groups }}"

--- a/roles/add_groups/tasks/main.yaml
+++ b/roles/add_groups/tasks/main.yaml
@@ -17,6 +17,8 @@
       Match all
   when: item.deny
   loop: "{{ ssh_groups }}"
+  notify:
+    - Restart sshd
 
 - name: Create banner message file
   copy:

--- a/roles/ohpc_add_rabbitmq_agents/templates/config.j2
+++ b/roles/ohpc_add_rabbitmq_agents/templates/config.j2
@@ -7,6 +7,10 @@ Port = {{ rabbitmq_port }}
 
 Valid_state = {{ valid_user_state }}
 
+# dict values in lock_groups correspond to the states defined above
+# eg: {"state":"group"}
+lock_groups = {{ lock_groups }}
+
 # Default function timeout
 Function_timeout = {{ function_timeout }}
 


### PR DESCRIPTION
This PR is built on top of PR #351 and adds `lock_groups` config value to `rabbit_config.py` via templating from group_vars/all