### PR TITLE
Feat: Add remote user to flask app apache file

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -12,6 +12,11 @@ ProxyPassReverse /static http://127.0.0.1:{{ user_register_app_port }}/static
     ShibRequestSetting requireSession 1
     Require valid-user
     ShibUseHeaders On
+    RewriteCond %{IS_SUBREQ} ^false$
+    RewriteCond %{HTTP:REMOTE_USER} '([a-zA-Z0-9_.+-]+)@uab.edu$' [OR]
+    RewriteCond %{HTTP:REMOTE_USER} 'urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$'
+    RewriteRule . - [E=REMOTE_USER:%1]
+    RequestHeader set REMOTE_USER %{REMOTE_USER}e
 </Location>
 
 <Location "/static/">


### PR DESCRIPTION
Added Rewrite conditions and rule to get and parse REMOTE_USER value in the flask app
REMOTE_USER value is cleaned to have blazer id (for *@uab.edu accounts) or email id (in case of XIAS accounts)