### PR TITLE
Feat: Added set RequestHeader value in ood_portal file

### DIFF
--- a/roles/ood_shib_config/tasks/main.yaml
+++ b/roles/ood_shib_config/tasks/main.yaml
@@ -60,6 +60,7 @@
         - "RewriteCond %{HTTP:REMOTE_USER} '([a-zA-Z0-9_.+-]+)@uab.edu$' [OR]"
         - "RewriteCond %{HTTP:REMOTE_USER} 'urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$'"
         - "RewriteRule . - [E=REMOTE_USER:%1]"
+        - "RequestHeader set REMOTE_USER %{REMOTE_USER}e"
         #- "RewriteCond %{IS_SUBREQ} ^false$"
         #- "RewriteCond %{HTTP:unscoped-affiliation} !({{ valid_eppa|join('|') }}) [NC]"
         #- "RewriteRule ^(.*)$ /{{ user_register_app }} [L]"


### PR DESCRIPTION
Set RequestHeader value of REMOTE_USER for ood_portal
REMOTE_USER value is cleaned to have blazer id (for *@uab.edu accounts) or email id (in case of XIAS accounts)