### PR TITLE
Fix slow loading in OOD 2.0

### DIFF
--- a/ood-cod.yaml
+++ b/ood-cod.yaml
@@ -2,6 +2,7 @@
 - hosts: chroot
   roles:
     - { name: 'ood', tags: 'ood' }
+    - { name: 'ood_fix_cache', tags: 'ood_fix_cache' }
     - { name: 'ood_enable_ssl', tags: 'ood_enable_ssl' }
     - { name: 'ood_jupyter', tags: 'ood_jupyter', when: jupyter_provision}
     - { name: 'ood_vnc_form', tags: 'ood_vnc_form' }

--- a/roles/ood_fix_cache/tasks/main.yaml
+++ b/roles/ood_fix_cache/tasks/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: Remove header setting from template
+  lineinfile:
+    path: /opt/ood/ood-portal-generator/templates/ood-portal.conf.erb
+    line: '  Header Set Cache-Control "max-age=0, no-store"'
+    state: absent
+    backup: yes
+
+- name: Update ood portal file
+  command: /opt/ood/ood-portal-generator/sbin/update_ood_portal
+  ignore_errors: yes


### PR DESCRIPTION
After investigation, it's due to the cache not being saved. 
The role can be removed after OSC fixes it in OOD 2.1