### PR TITLE
Replace ood app repo with uabrc repos

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -118,7 +118,7 @@
 
 #Jupyter related
   jupyter_provision: false
-  jupyter_ood_app_repo: "https://github.com/OSC/bc_example_jupyter.git"
+  jupyter_ood_app_repo: "https://github.com/uabrc/bc_example_jupyter.git"
   jupyter_ood_app_refspec: "{{ github_refspec }}"
   jupyter_ood_app_version: "v1.1"
 
@@ -142,7 +142,7 @@
   matlab_module_appdir: "matlab"
   matlab_module_file: "r2018a"
   matlab_ver: "{{ matlab_module_file }}"
-  matlab_ood_app_repo: "https://github.com/OSC/bc_osc_matlab.git"
+  matlab_ood_app_repo: "https://github.com/uabrc/bc_osc_matlab.git"
   matlab_ood_app_refspec: "{{ github_refspec }}"
   matlab_ood_app_version: "v1.1"
 


### PR DESCRIPTION
In order to use our own release tags, point it to our repo.