### PR TITLE
Remove module load from command

### DIFF
--- a/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
+++ b/roles/cod_rabbitmq_agents_cloud/tasks/main.yaml
@@ -36,7 +36,7 @@
     state: restarted
 
 - name: Create nossh group
-  command: module load cmsh && cmsh -c "group; add nossh; commit"
+  command: cmsh -c "group; add nossh; commit"
 
 - name: Add nossh group to denygroups
   lineinfile:


### PR DESCRIPTION
This task throw error:
```
TASK [cod_rabbitmq_agents_cloud : Create nossh group] ****************************************************************************************************************************************************************************************
fatal: [ohpc]: FAILED! => {"changed": false, "cmd": "module load cmsh '&&' cmsh -c 'group; add nossh; commit'", "msg": "[Errno 2] No such file or directory", "rc": 2}
```

After removing `module load cmsh` part of the command, it works fine.