### PR TITLE
Set ood packer hosts to default

### DIFF
--- a/ood-packer.yaml
+++ b/ood-packer.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: ood 
+- hosts: default
   become: true
   roles:
     - { name: 'ood', tags: 'ood' }


### PR DESCRIPTION
Since the playbook is running inside the VM, use `default` to run locally 