### PR TITLE
Update enable lmod

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -288,6 +288,7 @@
 # Lmod
   lmod_loc: "/usr/share/lmod/lmod"
   lmod_archive_loc: "{{ cluster_shared_folder }}/rc/lmod"
+  lmod_cache_loc: "/cm/shared"
   lmod_log_loc: "/var/log"
   lmod_log_filename: "{{ lmod_log_loc }}/moduleUsage.log"
   lmod_module_tracking_loc: "{{ lmod_loc }}/tools/tracking_module_usage"

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -19,6 +19,29 @@
     - { path: 'cm-lmod-init.csh', regexp: 'LMOD.*$', replace: 'LMOD "1"'}
   when: '"cm" in ansible_facts.packages.Lmod[0].release'
 
+- name: Update Lmod Spider Cache setting
+  ansible.builtin.replace:
+    path: "{{ lmod_loc }}/init/lmodrc.lua"
+    regexp: '(\["{{ item.key }}"\] = ).*$'
+    replace: \1 "{{ item.value }}",
+  loop:
+    - {"key": "dir", "value": "{{ lmod_cache_loc }}/sysCacheDir"}
+    - {"key": "timestamp", "value": "{{ lmod_cache_loc }}/sysCacheTS.txt"}
+  when: '"cm" in ansible_facts.packages.Lmod[0].release'
+
+- name: Add Lmod Spider Cache setting
+  ansible.builtin.blockinfile:
+    marker: "-- {mark} ANSIBLE MANAGED BLOCK"
+    path: "{{ lmod_loc }}/init/lmodrc.lua"
+    block: |
+      scDescriptT = {
+        {
+          ["dir"] = "{{ lmod_cache_loc }}/sysCacheDir",
+          ["timestamp"] = "{{ lmod_cache_loc }}/sysCacheTS.txt",
+        },
+      }
+  when: '"cm" not in ansible_facts.packages.Lmod[0].release'
+
 - name: Put DefaultModules in place
   template:
     src: DefaultModules.lua.j2

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -3,30 +3,30 @@
   ansible.builtin.package_facts:
     manager: "auto"
 
-- name: Make sure lmod config is installed with cm version
-  ansible.builtin.yum:
-    name: cm-modules-init-client
-    state: present
-  when: '"cm" in ansible_facts.packages.Lmod[0].release'
+- name: Tasks only needed in cm version
+  block:
+    - name: Make sure lmod config is installed with cm version
+      ansible.builtin.yum:
+        name: cm-modules-init-client
+        state: present
 
-- name: Enable Lmod
-  replace:
-    path: "{{ enable_lmod_prefix }}/etc/sysconfig/modules/lmod/{{ item.path }}"
-    regexp: "{{ item.regexp }}"
-    replace: "{{ item.replace }}"
-  loop:
-    - { path: 'cm-lmod-init.sh', regexp: 'LMOD=.*$', replace: 'LMOD=1'}
-    - { path: 'cm-lmod-init.csh', regexp: 'LMOD.*$', replace: 'LMOD "1"'}
-  when: '"cm" in ansible_facts.packages.Lmod[0].release'
+    - name: Enable Lmod
+      replace:
+        path: "{{ enable_lmod_prefix }}/etc/sysconfig/modules/lmod/{{ item.path }}"
+        regexp: "{{ item.regexp }}"
+        replace: "{{ item.replace }}"
+      loop:
+        - { path: 'cm-lmod-init.sh', regexp: 'LMOD=.*$', replace: 'LMOD=1'}
+        - { path: 'cm-lmod-init.csh', regexp: 'LMOD.*$', replace: 'LMOD "1"'}
 
-- name: Update Lmod Spider Cache setting
-  ansible.builtin.replace:
-    path: "{{ lmod_loc }}/init/lmodrc.lua"
-    regexp: '(\["{{ item.key }}"\] = ).*$'
-    replace: \1 "{{ item.value }}",
-  loop:
-    - {"key": "dir", "value": "{{ lmod_cache_loc }}/sysCacheDir"}
-    - {"key": "timestamp", "value": "{{ lmod_cache_loc }}/sysCacheTS.txt"}
+    - name: Update Lmod Spider Cache setting
+      ansible.builtin.replace:
+        path: "{{ lmod_loc }}/init/lmodrc.lua"
+        regexp: '(\["{{ item.key }}"\] = ).*$'
+        replace: \1 "{{ item.value }}",
+      loop:
+        - {"key": "dir", "value": "{{ lmod_cache_loc }}/sysCacheDir"}
+        - {"key": "timestamp", "value": "{{ lmod_cache_loc }}/sysCacheTS.txt"}
   when: '"cm" in ansible_facts.packages.Lmod[0].release'
 
 - name: Add Lmod Spider Cache setting

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -1,13 +1,13 @@
 ---
-- name: Check if it's cm provided Lmod
-  shell: yum list installed | grep Lmod
-  register: yum_lmod_pkg
+- name: Get package facts
+  ansible.builtin.package_facts:
+    manager: "auto"
 
 - name: Make sure lmod config is installed with cm version
   ansible.builtin.yum:
     name: cm-modules-init-client
     state: present
-  when: '"_cm" in yum_lmod_pkg.stdout'
+  when: '"cm" in ansible_facts.packages.Lmod[0].release'
 
 - name: Enable Lmod
   replace:
@@ -17,7 +17,7 @@
   loop:
     - { path: 'cm-lmod-init.sh', regexp: 'LMOD=.*$', replace: 'LMOD=1'}
     - { path: 'cm-lmod-init.csh', regexp: 'LMOD.*$', replace: 'LMOD "1"'}
-  when: '"_cm" in yum_lmod_pkg.stdout'
+  when: '"cm" in ansible_facts.packages.Lmod[0].release'
 
 - name: Put DefaultModules in place
   template:

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -3,6 +3,12 @@
   shell: yum list installed | grep Lmod
   register: yum_lmod_pkg
 
+- name: Make sure lmod config is installed with cm version
+  ansible.builtin.yum:
+    name: cm-modules-init-client
+    state: present
+  when: '"_cm" in yum_lmod_pkg.stdout'
+
 - name: Enable Lmod
   replace:
     path: "{{ enable_lmod_prefix }}/etc/sysconfig/modules/lmod/{{ item.path }}"

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -21,7 +21,7 @@
 
     - name: Update Lmod Spider Cache setting
       ansible.builtin.replace:
-        path: "{{ lmod_loc }}/init/lmodrc.lua"
+        path: "{{ enable_lmod_prefix }}/{{ lmod_loc }}/init/lmodrc.lua"
         regexp: '(\["{{ item.key }}"\] = ).*$'
         replace: \1 "{{ item.value }}",
       loop:
@@ -32,7 +32,7 @@
 - name: Add Lmod Spider Cache setting
   ansible.builtin.blockinfile:
     marker: "-- {mark} ANSIBLE MANAGED BLOCK"
-    path: "{{ lmod_loc }}/init/lmodrc.lua"
+    path: "{{ enable_lmod_prefix }}/{{ lmod_loc }}/init/lmodrc.lua"
     block: |
       scDescriptT = {
         {

--- a/roles/enable_lmod/tasks/main.yaml
+++ b/roles/enable_lmod/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Check if it's cm provided Lmod
+  shell: yum list installed | grep Lmod
+  register: yum_lmod_pkg
+
 - name: Enable Lmod
   replace:
     path: "{{ enable_lmod_prefix }}/etc/sysconfig/modules/lmod/{{ item.path }}"
@@ -7,6 +11,7 @@
   loop:
     - { path: 'cm-lmod-init.sh', regexp: 'LMOD=.*$', replace: 'LMOD=1'}
     - { path: 'cm-lmod-init.csh', regexp: 'LMOD.*$', replace: 'LMOD "1"'}
+  when: '"_cm" in yum_lmod_pkg.stdout'
 
 - name: Put DefaultModules in place
   template:


### PR DESCRIPTION
When installed non-cm version of Lmod, it's enabled by default, no need to modify this file to enable it.
Plus, the file is actually provided by a different package called `cm-modules-init-client`, so need to ensure it's installed before modifying the file.