### PR TITLE
Fix env var job archive

### DIFF
--- a/roles/ood/templates/bc_desktop/submit.yml.erb
+++ b/roles/ood/templates/bc_desktop/submit.yml.erb
@@ -1,7 +1,5 @@
 ---
 script:
-  job_environment:
-    USER: "<%= ENV['USER'] %>"
   native:
     - "-N"
     - "1"

--- a/roles/ood_vnc_form/files/vnc-submit.yml.erb
+++ b/roles/ood_vnc_form/files/vnc-submit.yml.erb
@@ -1,5 +1,7 @@
 ---
 script:
+  job_environment:
+    USER: "<%= ENV['USER'] %>"
   native:
     - "-N 1"
     - "-n <%= bc_num_slots.blank? ? 1 : bc_num_slots.to_i %>"


### PR DESCRIPTION
Fixes OOD hpc desktop jobs not being archived by job_archiver due to USER env var not being passed to the slurm job from OOD