### PR TITLE
Add a playbook with roles in CRI_XCBC to be used for building compute img

### DIFF
--- a/compute-packer.yaml
+++ b/compute-packer.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: compute
+  become: true
+  roles:
+    - { name: 'enable_lmod', tags: 'enable_lmod' }
+    - { name: 'lmod_user', tags: 'lmod_user' }
+    - { name: 'local_user', tags: 'local_user', when: local_user.username | length > 0 }


### PR DESCRIPTION
PR to add roles that are to be run while building compute image in packer-openstack-hpc-image but are in the CRI_XCBC project. So we create a separate playbook to be run with packer ansible provisioner in packer-openstack-hpc-image project.