### PR TITLE
Fix file reference in md5_value lookup

### DIFF
--- a/roles/install_node_exporter/tasks/main.yaml
+++ b/roles/install_node_exporter/tasks/main.yaml
@@ -5,7 +5,7 @@
     dest: "/tmp/{{ sha256 }}"
 
 - set_fact:
-    md5_value: "{{ lookup('file', '/tmp/{{ sha256 }}') }}"
+    md5_value: "{{ lookup('{{ file }}', '/tmp/{{ sha256 }}') }}"
 
 - name: Download node_exporter binary
   get_url:


### PR DESCRIPTION
The lookup function appears to be failing due trying to find a literal entry of "file" rather than the file name from the vars.  Adding braces to reference variable.

@rtripath89 