### PR TITLE
Load appropriate default modules in compute,GPU,login nodes for root

### DIFF
--- a/group_vars/compute
+++ b/group_vars/compute
@@ -1,0 +1,3 @@
+---
+  lmod_root_default_modules: ["shared", "slurm"]
+  lmod_default_modules: ["shared", "slurm", "rc-base"]


### PR DESCRIPTION
This will match the default modules in Cheaha and on image builds
Resolves https://gitlab.rc.uab.edu/rc/devops/-/issues/383