### PR TITLE
Fix baseurl for yum sclo repo

### DIFF
--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -22,7 +22,7 @@
     section: centos-sclo-rh
     option: baseurl
     #value: http://www.gtlib.gatech.edu/pub/centos/7/sclo/$basearch/rh/
-    value: http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+    value: http://vault.centos.org/centos/7/sclo/$basearch/rh/
     backup: yes
 
 - name: Fix remove mirrorlist from SCL RH7

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -21,7 +21,6 @@
     path: "/etc/yum.repos.d/{{ item.filename }}"
     section: "{{ item.section }}"
     option: baseurl
-    #value: http://www.gtlib.gatech.edu/pub/centos/7/sclo/$basearch/rh/
     value: http://vault.centos.org/centos/7/sclo/$basearch/rh/
     backup: yes
   loop:

--- a/roles/ood/tasks/main.yaml
+++ b/roles/ood/tasks/main.yaml
@@ -18,20 +18,26 @@
 
 - name: Fix failing SCL RH7 repo with static baseurl
   ini_file:
-    path: /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    section: centos-sclo-rh
+    path: "/etc/yum.repos.d/{{ item.filename }}"
+    section: "{{ item.section }}"
     option: baseurl
     #value: http://www.gtlib.gatech.edu/pub/centos/7/sclo/$basearch/rh/
     value: http://vault.centos.org/centos/7/sclo/$basearch/rh/
     backup: yes
+  loop:
+    - {"filename": "CentOS-SCLo-scl-rh.repo", "section": "centos-sclo-rh"}
+    - {"filename": "CentOS-SCLo-scl.repo", "section": "centos-sclo-sclo"}
 
 - name: Fix remove mirrorlist from SCL RH7
   ini_file:
-    path: /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    section: centos-sclo-rh
+    path: "/etc/yum.repos.d/{{ item.filename }}"
+    section: "{{ item.section }}"
     state: absent
     option: mirrorlist
     backup: no
+  loop:
+    - {"filename": "CentOS-SCLo-scl-rh.repo", "section": "centos-sclo-rh"}
+    - {"filename": "CentOS-SCLo-scl.repo", "section": "centos-sclo-sclo"}
 
 - name: Add Open OnDemand’s repository hosted by the Ohio Supercomputer Center
   yum:


### PR DESCRIPTION
The pipeline with fix in the packer repo did fix the build for `base` and `compute` but not `ood`. Here's the pipeline result from the PR: https://gitlab.rc.uab.edu/rc/packer-openstack-hpc-image/-/jobs/46193
```
1720471919,,ui,message,    openstack.image: fatal: [default]: FAILED! => {"changed": false%!(PACKER_COMMA) "msg": "Failure talking to yum: Cannot find a valid baseurl for repo: centos-sclo-sclo/x86_64"}
```

Since the CentOS 7 EOL was June 30, 2024, the mirrorlist.centos.org site has been taken down. Replace the url with vault.centos.org
