### PR TITLE
feat: Swap SSH and sshpiper ports

### DIFF
--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -81,9 +81,3 @@
     enabled: yes
     state: started
 
-- name: Ensure SSH service is enabled and started
-  ansible.builtin.service:
-    name: sshd
-    enabled: yes
-    state: started
-

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -54,11 +54,6 @@
     dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
     backup: true
 
-- name: Restart sshpiper
-  ansible.builtin.systemd:
-    name: sshpiperd
-    state: restarted
-
 - name: Update Shorewall rules for SSH and sshpiper
   ansible.builtin.blockinfile:
     path: /etc/shorewall/rules
@@ -70,7 +65,7 @@
       ACCEPT:info   net            fw              tcp     2222
 
 - name: Restart Shorewall
-  ansible.builtin.systemd:
+  ansible.builtin.service:
     name: shorewall
     state: restarted
 
@@ -81,13 +76,18 @@
     backup: true
 
 - name: Enable and start sshpiper service
-  ansible.builtin.systemd:
+  ansible.builtin.service:
     name: sshpiperd
     enabled: yes
     state: started
 
+- name: Restart sshpiper
+  ansible.builtin.service:
+    name: sshpiperd
+    state: restarted
+
 - name: Ensure SSH service is enabled and started
-  ansible.builtin.systemd:
+  ansible.builtin.service:
     name: sshd
     enabled: yes
     state: started
@@ -106,6 +106,3 @@
   register: ssh_check
   ignore_errors: yes
 
-- name: Reload systemd
-  ansible.builtin.systemd:
-    daemon_reload: yes

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -54,12 +54,6 @@
     dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
     backup: true
 
-- name: Update sshpiper configuration to use port 22
-  ansible.builtin.lineinfile:
-    path: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
-    regexp: '^(\s*)listen_addr:'
-    line: '\1listen_addr: 0.0.0.0:22'
-
 - name: Restart sshpiper
   ansible.builtin.systemd:
     name: sshpiperd
@@ -72,8 +66,6 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     backup: true
     block: |
-      # -- Allow port 22 traffic for sshpiper from internet to master
-      ACCEPT:info   net            fw              tcp     22
       # -- Allow port 2222 traffic for SSH from internet to master
       ACCEPT:info   net            fw              tcp     2222
 

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -81,11 +81,6 @@
     enabled: yes
     state: started
 
-- name: Restart sshpiper
-  ansible.builtin.service:
-    name: sshpiperd
-    state: restarted
-
 - name: Ensure SSH service is enabled and started
   ansible.builtin.service:
     name: sshd

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
+
 - name: Download Go
   get_url:
-    url: "{{ go_download_url }}" 
+    url: "{{ go_download_url }}"
     dest: "{{ go_download_path }}"
 
 - name: Extract Go
@@ -36,20 +37,33 @@
   environment:
     PATH: "{{ ansible_env.PATH }}:{{go_binary_path}}/go/bin"
 
-
 - name: Change SSH port to 2222
   ansible.builtin.lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?Port '
     line: 'Port 2222'
-  notify: Restart SSH
+
+- name: Restart SSH service
+  ansible.builtin.systemd:
+    name: sshd
+    state: restarted
+
+- name: Configure sshpiper yaml plugin
+  ansible.builtin.template:
+    src: sshpiperd.yaml.j2
+    dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
+    backup: true
 
 - name: Update sshpiper configuration to use port 22
   ansible.builtin.lineinfile:
     path: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
     regexp: '^(\s*)listen_addr:'
     line: '\1listen_addr: 0.0.0.0:22'
-  notify: Restart sshpiper
+
+- name: Restart sshpiper
+  ansible.builtin.systemd:
+    name: sshpiperd
+    state: restarted
 
 - name: Update Shorewall rules for SSH and sshpiper
   ansible.builtin.blockinfile:
@@ -62,14 +76,17 @@
       ACCEPT:info   net            fw              tcp     22
       # -- Allow port 2222 traffic for SSH from internet to master
       ACCEPT:info   net            fw              tcp     2222
-  notify: Restart Shorewall
+
+- name: Restart Shorewall
+  ansible.builtin.systemd:
+    name: shorewall
+    state: restarted
 
 - name: Install systemd service file for sshpiper
   ansible.builtin.template:
     src: sshpiperd.service.j2
     dest: /etc/systemd/system/sshpiperd.service
     backup: true
-  notify: Reload systemd
 
 - name: Enable and start sshpiper service
   ansible.builtin.systemd:
@@ -96,27 +113,6 @@
     timeout: 5
   register: ssh_check
   ignore_errors: yes
-
-- name: Display verification results
-  ansible.builtin.debug:
-    msg: 
-      - "sshpiper on port 22: {{ 'OK' if sshpiper_check.state == 'started' else 'FAILED' }}"
-      - "SSH on port 2222: {{ 'OK' if ssh_check.state == 'started' else 'FAILED' }}"
-
-- name: Restart SSH
-  ansible.builtin.systemd:
-    name: sshd
-    state: restarted
-
-- name: Restart sshpiper
-  ansible.builtin.systemd:
-    name: sshpiperd
-    state: restarted
-
-- name: Restart Shorewall
-  ansible.builtin.systemd:
-    name: shorewall
-    state: restarted
 
 - name: Reload systemd
   ansible.builtin.systemd:

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Download Go
   get_url:
     url: "{{ go_download_url }}" 
@@ -37,34 +36,88 @@
   environment:
     PATH: "{{ ansible_env.PATH }}:{{go_binary_path}}/go/bin"
 
-- name: Configure sshpiper yaml plugin
-  ansible.builtin.template:
-    src: sshpiperd.yaml.j2
-    dest: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
-    backup: true
 
-- name: Allow port 2222 traffic for sshpiper in Shorewall
+- name: Change SSH port to 2222
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regexp: '^#?Port '
+    line: 'Port 2222'
+  notify: Restart SSH
+
+- name: Update sshpiper configuration to use port 22
+  ansible.builtin.lineinfile:
+    path: "{{ sshpiper_dest_dir }}/sshpiperd.yaml"
+    regexp: '^(\s*)listen_addr:'
+    line: '\1listen_addr: 0.0.0.0:22'
+  notify: Restart sshpiper
+
+- name: Update Shorewall rules for SSH and sshpiper
   ansible.builtin.blockinfile:
     path: /etc/shorewall/rules
     insertbefore: "^#LAST LINE"
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     backup: true
     block: |
-      # -- Allow port 2222 traffic for sshpiper from internet to master
+      # -- Allow port 22 traffic for sshpiper from internet to master
+      ACCEPT:info   net            fw              tcp     22
+      # -- Allow port 2222 traffic for SSH from internet to master
       ACCEPT:info   net            fw              tcp     2222
-
-- name: Restart Shorewall service
-  ansible.builtin.systemd:
-    name: shorewall
-    state: restarted
+  notify: Restart Shorewall
 
 - name: Install systemd service file for sshpiper
   ansible.builtin.template:
     src: sshpiperd.service.j2
     dest: /etc/systemd/system/sshpiperd.service
     backup: true
-  
-- name: Enable sshpiperd service
-  ansible.builtin.service:
+  notify: Reload systemd
+
+- name: Enable and start sshpiper service
+  ansible.builtin.systemd:
     name: sshpiperd
     enabled: yes
+    state: started
+
+- name: Ensure SSH service is enabled and started
+  ansible.builtin.systemd:
+    name: sshd
+    enabled: yes
+    state: started
+
+- name: Check if sshpiper is listening on port 22
+  ansible.builtin.wait_for:
+    port: 22
+    timeout: 5
+  register: sshpiper_check
+  ignore_errors: yes
+
+- name: Check if SSH is listening on port 2222
+  ansible.builtin.wait_for:
+    port: 2222
+    timeout: 5
+  register: ssh_check
+  ignore_errors: yes
+
+- name: Display verification results
+  ansible.builtin.debug:
+    msg: 
+      - "sshpiper on port 22: {{ 'OK' if sshpiper_check.state == 'started' else 'FAILED' }}"
+      - "SSH on port 2222: {{ 'OK' if ssh_check.state == 'started' else 'FAILED' }}"
+
+- name: Restart SSH
+  ansible.builtin.systemd:
+    name: sshd
+    state: restarted
+
+- name: Restart sshpiper
+  ansible.builtin.systemd:
+    name: sshpiperd
+    state: restarted
+
+- name: Restart Shorewall
+  ansible.builtin.systemd:
+    name: shorewall
+    state: restarted
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -92,17 +92,3 @@
     enabled: yes
     state: started
 
-- name: Check if sshpiper is listening on port 22
-  ansible.builtin.wait_for:
-    port: 22
-    timeout: 5
-  register: sshpiper_check
-  ignore_errors: yes
-
-- name: Check if SSH is listening on port 2222
-  ansible.builtin.wait_for:
-    port: 2222
-    timeout: 5
-  register: ssh_check
-  ignore_errors: yes
-

--- a/roles/sshpiper/templates/sshpiperd.service.j2
+++ b/roles/sshpiper/templates/sshpiperd.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart= {{ sshpiper_bin_dir }}/sshpiperd --log-level=trace {{ sshpiper_bin_dir }}/yaml --config {{ sshpiper_dest_dir }}/sshpiperd.yaml --no-check-perm
+ExecStart= {{ sshpiper_bin_dir }}/sshpiperd -p 22 --log-level=trace {{ sshpiper_bin_dir }}/yaml --config {{ sshpiper_dest_dir }}/sshpiperd.yaml --no-check-perm
 Restart=on-failure
 User=root
 


### PR DESCRIPTION
Updated the Ansible role to configure sshpiper to run on port 22 and the SSH service on port 2222.
Modified the SSH configuration to change the listening port.
Adjusted the sshpiper configuration to listen on port 22.
Updated Shorewall rules to allow traffic on both ports.
Added service management tasks to ensure both sshpiper and SSH are enabled and started.