### PR TITLE
Change paths to reflect the home dir paths for gpfs migration groups

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -348,5 +348,5 @@
   sshpiper_dest_dir: "/opt/sshpiper"
   sshpiper_bin_dir: "{{ sshpiper_dest_dir }}/out"
   gpfs_groups:
-    - {"name": "gpfs4", "authorized_keys":"/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login001", "private_key":"/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}
-    - {"name": "gpfs5", "authorized_keys":"/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login002", "private_key":"/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}
+    - {"name": "gpfs4", "authorized_keys":"/gpfs4/data/user/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login001", "private_key":"/gpfs4/data/user/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}
+    - {"name": "gpfs5", "authorized_keys":"/gpfs5/data/user/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login002", "private_key":"/gpfs5/data/user/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}


### PR DESCRIPTION
This PR will change the paths to the home dir to look for authorized_keys and private_keys. It reflects the different home dir paths for different GPFS migration groups in CoD cluster.