### PR TITLE
Update rabbitmq agents branch to with main

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -258,7 +258,7 @@
   rabbitmq_port: "5672"
   rabbitmq_agents_loc: "/cm/shared/rabbitmq_agents"
   rabbitmq_agents_repo: "https://gitlab.rc.uab.edu/rc/rabbitmq_agents.git"
-  rabbitmq_agents_version: "feat-cod-rmq"
+  rabbitmq_agents_version: "main"
   rabbitmq_agents_refspec: "{{ gitlab_refspec }}"
   rabbitmq_agents_service_user: "root"
   rabbitmq_agents_db_path: ".agent_db"


### PR DESCRIPTION
`feat-cod-rmq` has been merged into `main` and should not be used anymore.


Fixes https://gitlab.rc.uab.edu/rc/gpfs5-migration/-/issues/32