### PR TITLE
Add SSH host keys management feature

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -339,9 +339,9 @@
   node_exporter_scriptdir: "{{ playbook_dir }}"
 
 #SSH Host Keys
-  enable_ssh_host_keys: true
-  ssh_host_keys_s3_bucket: "sshhostkeys"
-  ssh_host_keys_s3_object: "ssh_host_keys.tar.gz"
+  enable_ssh_host_keys: false
+  ssh_host_keys_s3_bucket: ""
+  ssh_host_keys_s3_object: ""
 
 # sshpiper
   enable_sshpiper: false

--- a/group_vars/all
+++ b/group_vars/all
@@ -338,6 +338,11 @@
   node_exporter_sha256: "sha256sums.txt"
   node_exporter_scriptdir: "{{ playbook_dir }}"
 
+#SSH Host Keys
+  enable_ssh_host_keys: true
+  ssh_host_keys_s3_bucket: "sshhostkeys"
+  ssh_host_keys_s3_object: "ssh_host_keys.tar.gz"
+
 # sshpiper
   enable_sshpiper: false
   go_download_url: "https://go.dev/dl/go1.22.4.linux-amd64.tar.gz"

--- a/ohpc-build.yaml
+++ b/ohpc-build.yaml
@@ -13,4 +13,5 @@
     - { name: 'ohpc_user_reg', tags: 'ohpc_user_reg', when: enable_user_reg }
     - { name: 'ohpc_add_rabbitmq_agents', tags: 'ohpc_add_rabbitmq_agents', when: enable_user_reg }
     - { name: 'sshpiper', tags: 'sshpiper', when: enable_sshpiper }
+    - { name: 'ssh_host_keys', tags: 'ssh_host_keys', when: enable_ssh_host_keys }
 

--- a/ohpc-build.yaml
+++ b/ohpc-build.yaml
@@ -13,5 +13,4 @@
     - { name: 'ohpc_user_reg', tags: 'ohpc_user_reg', when: enable_user_reg }
     - { name: 'ohpc_add_rabbitmq_agents', tags: 'ohpc_add_rabbitmq_agents', when: enable_user_reg }
     - { name: 'sshpiper', tags: 'sshpiper', when: enable_sshpiper }
-    - { name: 'ssh_host_keys', tags: 'ssh_host_keys', when: enable_ssh_host_keys }
 

--- a/ohpc.yaml
+++ b/ohpc.yaml
@@ -16,3 +16,4 @@
     - { name: 'ohpc_ansys', tags: 'ohpc_ansys', when: ansys_provision }
     - { name: 'ohpc_add_rstudio', tags: 'ohpc_add_rstudio', when: rstudio_provision }
     - { name: 'ohpc_user_reg', tags: 'ohpc_user_reg', when: enable_user_reg }
+    - { name: 'ssh_host_keys', tags: 'ssh_host_keys', when: enable_ssh_host_keys }

--- a/roles/ssh_host_keys/tasks/main.yaml
+++ b/roles/ssh_host_keys/tasks/main.yaml
@@ -13,7 +13,7 @@
 
 - name: Unpack SSH host keys to /etc/ssh
   unarchive:
-    src: "/tmp/ssh_host_keys.tar.gz"
+    src: "/tmp/{{ ssh_host_keys_s3_object }}"
     dest: "/etc/ssh"
     remote_src: yes
 

--- a/roles/ssh_host_keys/tasks/main.yaml
+++ b/roles/ssh_host_keys/tasks/main.yaml
@@ -1,11 +1,17 @@
 ---
+- name: Ensure destination directory exists
+  file:
+    path: /tmp/ssh_keys
+    state: directory
+    mode: '0755'
+
 - name: Download SSH host keys tar.gz from S3
   aws_s3:
     mode: get
     s3_url: "{{ s3_endpoint }}"
     bucket: "{{ ssh_host_keys_s3_bucket }}"
     object: "{{ ssh_host_keys_s3_object }}"
-    dest: "/tmp/"
+    dest: "/tmp/ssh_keys/{{ ssh_host_keys_s3_object }}"
     aws_access_key: "{{ lts_access_key }}"
     aws_secret_key: "{{ lts_secret_key }}"
   vars:
@@ -13,7 +19,7 @@
 
 - name: Unpack SSH host keys to /etc/ssh
   unarchive:
-    src: "/tmp/{{ ssh_host_keys_s3_object }}"
+    src: "/tmp/ssh_keys/{{ ssh_host_keys_s3_object }}"
     dest: "/etc/ssh"
     remote_src: yes
 
@@ -21,3 +27,4 @@
   ansible.builtin.service:
     name: sshd
     state: restarted
+

--- a/roles/ssh_host_keys/tasks/main.yaml
+++ b/roles/ssh_host_keys/tasks/main.yaml
@@ -1,0 +1,23 @@
+---
+- name: Download SSH host keys tar.gz from S3
+  aws_s3:
+    mode: get
+    s3_url: "{{ s3_endpoint }}"
+    bucket: "{{ ssh_host_keys_s3_bucket }}"
+    object: "{{ ssh_host_keys_s3_object }}"
+    dest: "/tmp/"
+    aws_access_key: "{{ lts_access_key }}"
+    aws_secret_key: "{{ lts_secret_key }}"
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+
+- name: Unpack SSH host keys to /etc/ssh
+  unarchive:
+    src: "/tmp/ssh_host_keys.tar.gz"
+    dest: "/etc/ssh"
+    remote_src: yes
+
+- name: Restart SSH service
+  ansible.builtin.service:
+    name: sshd
+    state: restarted


### PR DESCRIPTION
- Introduce new variables in group_vars/all for SSH host keys management:
  - enable_ssh_host_keys: Flag to enable/disable the feature
  - ssh_host_keys_s3_bucket: S3 bucket name for storing SSH host keys
  - ssh_host_keys_s3_object: Object name of the tar.gz file containing SSH host keys

- Update ohpc-build.yaml to include the new 'ssh_host_keys' role:
  - Add conditional execution based on enable_ssh_host_keys flag

- Create new role 'ssh_host_keys' with tasks to:
  - Download SSH host keys tar.gz from S3
  - Unpack the keys to /etc/ssh
  - Restart the SSH service