### PR TITLE
Set SELinux to permissive mode in sshpiper role

### DIFF
--- a/roles/sshpiper/tasks/main.yml
+++ b/roles/sshpiper/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set SELinux to permissive mode
+  ansible.posix.selinux:
+    policy: targeted
+    state: permissive
+  register: selinux_result
 
 - name: Download Go
   get_url:


### PR DESCRIPTION
- Add task to set SELinux to permissive mode using ansible.posix.selinux module