### PR TITLE
Add role to freeze slurm updates by cmd on CoD headnode

### DIFF
--- a/cod.yaml
+++ b/cod.yaml
@@ -5,3 +5,4 @@
     - { name: 'enable_lmod', tags: 'enable_lmod_image', vars: [{ enable_lmod_prefix: "{{ cm_def_img_path }}" }] }
     - { name: 'cod_login_node', tags: 'cod_login_node' }
     - { name: 'cod_compute_node', tags: 'cod_compute_node' }
+    - { name: 'cod_slurm', tags: 'cod_slurm'}

--- a/group_vars/all
+++ b/group_vars/all
@@ -351,3 +351,10 @@
   gpfs_groups:
     - {"name": "gpfs4", "authorized_keys":"/gpfs4/data/user/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login001", "private_key":"/gpfs4/data/user/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}
     - {"name": "gpfs5", "authorized_keys":"/gpfs5/data/user/home/$DOWNSTREAM_USER/.ssh/authorized_keys", "host": "login002", "private_key":"/gpfs5/data/user/home/$DOWNSTREAM_USER/.ssh/id_ecdsa"}
+
+# cod_slurm
+  frozen_file_list:
+    - /cm/shared/apps/slurm/var/etc/slurm/cgroup.conf
+    - /cm/shared/apps/slurm/var/etc/slurm/slurm.conf 
+    - /cm/shared/apps/slurm/var/etc/slurm/gres.conf
+

--- a/roles/cod_slurm/tasks/main.yml
+++ b/roles/cod_slurm/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Enable setting to prevent cmd from overwriting slurm config
+  ansible.builtin.lineinfile:
+    path: "/cm/local/apps/cmd/etc/cmd.conf"
+    regexp: '^FreezeChangesToSlurmConfig'
+    line: 'FreezeChangesToSlurmConfig = true'
+    state: present
+    backup: yes
+
+- name: Create a comma-separated string from frozen_file_list
+  ansible.builtin.set_fact:
+    frozen_files_joined: "{{ frozen_file_list | map('regex_replace', '(.*)', '\"\\1\"' ) | join(', ') }}"
+
+- name: Add FrozenFile entries to cmd.conf
+  ansible.builtin.lineinfile:
+    path: "/cm/local/apps/cmd/etc/cmd.conf" 
+    regexp: '^FrozenFile'
+    line: 'FrozenFile = { {{ frozen_files_joined }} }'
+    state: present
+    insertafter: '^# FrozenFile'
+    backup: yes
+  when: "'FreezeChangesToSlurmConfig = true' in lookup('file', '/cm/local/apps/cmd/etc/cmd.conf')"
+
+- name: Template slurm.conf
+  ansible.builtin.template:
+    src: slurm.conf.j2
+    dest: "{{ slurm_conf_path }}"
+
+- name: Reconfigure Slurm
+  ansible.builtin.command: scontrol reconfigure
+
+- name: Restart cmd
+  ansible.builtin.service:
+    name: cmd
+    state: restarted

--- a/roles/cod_slurm/templates/slurm.conf.j2
+++ b/roles/cod_slurm/templates/slurm.conf.j2
@@ -1,0 +1,105 @@
+#
+# See the slurm.conf man page for more information.
+#
+
+SlurmUser=slurm
+#SlurmdUser=root
+SlurmctldPort=6817
+SlurmdPort=6818
+AuthType=auth/munge
+#JobCredentialPrivateKey=
+#JobCredentialPublicCertificate=
+SlurmdSpoolDir=/cm/local/apps/slurm/var/spool
+SwitchType=switch/none
+MpiDefault=none
+SlurmctldPidFile=/var/run/slurmctld.pid
+SlurmdPidFile=/var/run/slurmd.pid
+#ProctrackType=proctrack/pgid
+ProctrackType=proctrack/cgroup
+#PluginDir=
+CacheGroups=0
+#FirstJobId=
+ReturnToService=2
+#MaxJobCount=
+#PlugStackConfig=
+#PropagatePrioProcess=
+#PropagateResourceLimits=
+#PropagateResourceLimitsExcept=
+#SrunProlog=
+#SrunEpilog=
+#TaskProlog=
+#TaskEpilog=
+TaskPlugin=task/cgroup
+JobSubmitPlugins=lua
+#TrackWCKey=no
+#TreeWidth=50
+#TmpFs=
+#UsePAM=
+#
+# TIMERS
+SlurmctldTimeout=300
+SlurmdTimeout=300
+InactiveLimit=0
+MinJobAge=300
+KillWait=30
+Waittime=0
+#
+# SCHEDULING
+#SchedulerAuth=
+#SchedulerPort=
+#SchedulerRootFilter=
+#PriorityType=priority/multifactor
+#PriorityDecayHalfLife=14-0
+#PriorityUsageResetPeriod=14-0
+#PriorityWeightFairshare=100000
+#PriorityWeightAge=1000
+#PriorityWeightPartition=10000
+#PriorityWeightJobSize=1000
+#PriorityMaxAge=1-0
+#
+# LOGGING
+SlurmctldDebug=3
+SlurmctldLogFile=/var/log/slurmctld
+SlurmdDebug=3
+SlurmdLogFile=/var/log/slurmd
+
+#JobCompType=jobcomp/filetxt
+#JobCompLoc=/cm/local/apps/slurm/var/spool/job_comp.log
+
+#
+# ACCOUNTING
+JobAcctGatherType=jobacct_gather/linux
+#JobAcctGatherType=jobacct_gather/cgroup
+#JobAcctGatherFrequency=30
+AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageUser=slurm
+# AccountingStorageLoc=slurm_acct_db
+# AccountingStoragePass=SLURMDBD_USERPASS
+AccountingStorageEnforce=limits
+
+# Server nodes
+SlurmctldHost=cluster-on-demand
+AccountingStorageHost=master
+
+# Nodes
+{% for i in range(1, num_compute_nodes +1) %}
+{% if i is odd() %}
+NodeName=c000{{i}} Procs=2 Feature= gpfs4
+{% else %}
+NodeName=c000{{i}} Procs=2 Feature= gpfs5
+{% endif %}
+{% endfor %}
+
+# Partitions
+PartitionName=defq Default=YES MinNodes=1 AllowGroups=ALL PriorityJobFactor=1 PriorityTier=1 OverSubscribe=NO PreemptMode=OFF AllowAccounts=ALL AllowQos=ALL Nodes=c[0001-000{{ num_compute_nodes }}]
+ClusterName=slurm
+# Satesave
+StateSaveLocation=/cm/shared/apps/slurm/var/cm/statesave/slurm
+# Generic resources types
+GresTypes=gpu
+# Epilog/Prolog section
+PrologSlurmctld=/cm/local/apps/cmd/scripts/prolog-prejob
+Prolog=/cm/local/apps/cmd/scripts/prolog
+Epilog=/cm/local/apps/cmd/scripts/epilog
+FastSchedule=0
+# Power saving section (disabled)

--- a/roles/cod_slurm/templates/slurm.conf.j2
+++ b/roles/cod_slurm/templates/slurm.conf.j2
@@ -30,7 +30,6 @@ ReturnToService=2
 #TaskProlog=
 #TaskEpilog=
 TaskPlugin=task/cgroup
-JobSubmitPlugins=lua
 #TrackWCKey=no
 #TreeWidth=50
 #TmpFs=


### PR DESCRIPTION
Slurm conf is updated by cmd so any changes we make will be overwritten Inorder to avoid this we make changes to cmd.conf so that slurm changes will be preserved on cmd restarts or system restarts. 

We template slurm config according to our requirements