### PR TITLE
Move cod_rabbitmq_agents_cloud role to cod.yaml

### DIFF
--- a/cod.yaml
+++ b/cod.yaml
@@ -3,5 +3,6 @@
   roles:
     - { name: 'enable_lmod', tags: 'enable_lmod' }
     - { name: 'enable_lmod', tags: 'enable_lmod_image', vars: [{ enable_lmod_prefix: "{{ cm_def_img_path }}" }] }
+    - { name: 'cod_rabbitmq_agents_cloud', tags: 'cod_rabbitmq_agents_cloud' }
     - { name: 'cod_login_node', tags: 'cod_login_node' }
     - { name: 'cod_compute_node', tags: 'cod_compute_node' }

--- a/ohpc-ops.yaml
+++ b/ohpc-ops.yaml
@@ -4,4 +4,3 @@
     - { name: 'ohpc_install_cloud'}
     - { name: 'compute_build_nodes_cloud', tags: 'compute_build_nodes_cloud' }
     - { name: 'nodes_vivify_cloud', tags: 'nodes_vivify_cloud' }
-    - { name: 'cod_rabbitmq_agents_cloud', tags: 'cod_rabbitmq_agents_cloud', when: cod_deploy }


### PR DESCRIPTION
This playbook is meant to be run on CoD headnode. `ohpc-ops.yaml` is for ohpc cluster. So move it to the appropriate playbook `cod.yaml`