### PR TITLE
Fix cod slurm role

### DIFF
--- a/cod.yaml
+++ b/cod.yaml
@@ -4,7 +4,7 @@
     - { name: 'enable_lmod', tags: 'enable_lmod' }
     - { name: 'enable_lmod', tags: 'enable_lmod_image', vars: [{ enable_lmod_prefix: "{{ cm_def_img_path }}" }] }
     - { name: 'cod_rabbitmq_agents_cloud', tags: 'cod_rabbitmq_agents_cloud' }
+    - { name: 'cod_slurm', tags: 'cod_slurm'}
     - { name: 'cod_login_node', tags: 'cod_login_node' }
     - { name: 'cod_compute_node', tags: 'cod_compute_node' }
-    - { name: 'cod_slurm', tags: 'cod_slurm'}
     - { name: 'job_submit_plugin', tags: 'job_submit_plugin', when: enable_job_submit_plugin}

--- a/roles/cod_slurm/tasks/main.yml
+++ b/roles/cod_slurm/tasks/main.yml
@@ -21,6 +21,11 @@
     backup: yes
   when: "'FreezeChangesToSlurmConfig = true' in lookup('file', '/cm/local/apps/cmd/etc/cmd.conf')"
 
+- name: Restart cmd
+  ansible.builtin.service:
+    name: cmd
+    state: restarted
+
 - name: Template slurm.conf
   ansible.builtin.template:
     src: slurm.conf.j2
@@ -29,7 +34,3 @@
 - name: Reconfigure Slurm
   ansible.builtin.command: scontrol reconfigure
 
-- name: Restart cmd
-  ansible.builtin.service:
-    name: cmd
-    state: restarted

--- a/roles/cod_slurm/tasks/main.yml
+++ b/roles/cod_slurm/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Template slurm.conf
+  ansible.builtin.template:
+    src: slurm.conf.j2
+    dest: "{{ slurm_conf_path }}"
+
+- name: Restart slurmctld
+  ansible.builtin.service:
+    name: slurmctld
+    state: restarted
+
 - name: Enable setting to prevent cmd from overwriting slurm config
   ansible.builtin.lineinfile:
     path: "/cm/local/apps/cmd/etc/cmd.conf"
@@ -24,16 +34,6 @@
 - name: Restart cmd
   ansible.builtin.service:
     name: cmd
-    state: restarted
-
-- name: Template slurm.conf
-  ansible.builtin.template:
-    src: slurm.conf.j2
-    dest: "{{ slurm_conf_path }}"
-
-- name: Restart slurmctld
-  ansible.builtin.service:
-    name: slurmctld
     state: restarted
 
 - name: Reconfigure Slurm

--- a/roles/cod_slurm/tasks/main.yml
+++ b/roles/cod_slurm/tasks/main.yml
@@ -31,6 +31,11 @@
     src: slurm.conf.j2
     dest: "{{ slurm_conf_path }}"
 
+- name: Restart slurmctld
+  ansible.builtin.service:
+    name: slurmctld
+    state: restarted
+
 - name: Reconfigure Slurm
   ansible.builtin.command: scontrol reconfigure
 

--- a/roles/cod_slurm/templates/slurm.conf.j2
+++ b/roles/cod_slurm/templates/slurm.conf.j2
@@ -83,9 +83,9 @@ AccountingStorageHost=master
 # Nodes
 {% for i in range(1, num_compute_nodes +1) %}
 {% if i is odd() %}
-NodeName=c000{{i}} Procs=2 Feature= gpfs4
+NodeName=c000{{i}} Procs=2 Feature=gpfs4
 {% else %}
-NodeName=c000{{i}} Procs=2 Feature= gpfs5
+NodeName=c000{{i}} Procs=2 Feature=gpfs5
 {% endif %}
 {% endfor %}
 

--- a/roles/cod_slurm/templates/slurm.conf.j2
+++ b/roles/cod_slurm/templates/slurm.conf.j2
@@ -100,5 +100,4 @@ GresTypes=gpu
 PrologSlurmctld=/cm/local/apps/cmd/scripts/prolog-prejob
 Prolog=/cm/local/apps/cmd/scripts/prolog
 Epilog=/cm/local/apps/cmd/scripts/epilog
-FastSchedule=0
 # Power saving section (disabled)


### PR DESCRIPTION
This PR will fix errors seen during the cod build. The `scontrol reconfigure` failed because of changes to slurm.conf in the cod_slurm role