### PR TITLE
Feat slapd conf

### DIFF
--- a/cod.yaml
+++ b/cod.yaml
@@ -1,6 +1,7 @@
 ---
 - hosts: headnode
   roles:
+    - { name: 'cod_slapd_conf', tags: 'cod_slapd_conf' }
     - { name: 'cod_fix_centos_yum', tags: 'cod_fix_centos_yum' }
     - { name: 'enable_lmod', tags: 'enable_lmod' }
     - { name: 'enable_lmod', tags: 'enable_lmod_image', vars: [{ enable_lmod_prefix: "{{ cm_def_img_path }}" }] }

--- a/roles/cod_slapd_conf/tasks/main.yaml
+++ b/roles/cod_slapd_conf/tasks/main.yaml
@@ -4,3 +4,8 @@
     path: /etc/sysconfig/slapd
     regexp: '^SLAPD_URLS='
     line: 'SLAPD_URLS="ldaps:/// ldapi:/// ldap:///"'
+
+- name: Restart slapd
+  ansible.builtin.service:
+    name: slapd
+    state: restarted

--- a/roles/cod_slapd_conf/tasks/main.yaml
+++ b/roles/cod_slapd_conf/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Update slapd.conf
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/slapd
+    regexp: '^SLAPD_URLS='
+    line: 'SLAPD_URLS="ldaps:/// ldapi:/// ldap:///"'


### PR DESCRIPTION
In order to accept ldap query, we need to config slapd to accept the URI `ldap:///`

Closes https://gitlab.rc.uab.edu/rc/devops/-/issues/572