### PR TITLE
Added a placeholder in the apache config so the value for the variabl…

### DIFF
--- a/roles/http_proxy/tasks/main.yml
+++ b/roles/http_proxy/tasks/main.yml
@@ -108,6 +108,15 @@
         src: front-end_conf.j2
         dest: /etc/httpd/conf.d/front-end.conf
 
+    - name: Replace OOD rewrite placeholder in Apache configuration
+      ansible.builtin.replace:
+        path: /etc/httpd/conf.d/front-end.conf
+        regexp: '# Placeholder for RewriteCond and RewriteRule\n\s*{{ ood_rewrite_placeholder }}'
+        replace: |
+          RewriteCond %{HTTP:REMOTE_USER} '([a-zA-Z0-9_.+-]+)@uab.edu$' [OR]
+          RewriteCond %{HTTP:REMOTE_USER} 'urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$'
+          RewriteRule . - [E=REMOTE_USER:%1]
+
     - name: Add apache rewritemap script config
       ansible.builtin.template:
         src: rewrite_map_config_py.j2

--- a/roles/http_proxy/templates/front-end_conf.j2
+++ b/roles/http_proxy/templates/front-end_conf.j2
@@ -36,8 +36,9 @@
     Require valid-user
     ShibUseHeaders On
     RewriteCond %{IS_SUBREQ} ^false$
-    RewriteCond %{HTTP:REMOTE_USER} '{{ ood_user_regex }}'
-    RewriteRule . - [E=PROXY_USER:%1]
+
+   # Placeholder for RewriteCond and RewriteRule
+   {{ ood_rewrite_placeholder }}
 
     RequestHeader set Proxy-User %{PROXY_USER}e
 


### PR DESCRIPTION
…e can be replaced during deploy

REMOTE_USER value has been tested with the apache rewrite conditions
    RewriteCond %{HTTP:REMOTE_USER} '([a-zA-Z0-9_.+-]+)@uab.edu$' [OR]
    RewriteCond %{HTTP:REMOTE_USER} 'urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$'
Hence hardcoded this block to replace the placeholder during deploy