### PR TITLE
allow unrestricted access to /var/www/ood/public directory

### DIFF
--- a/roles/http_proxy/templates/front-end_conf.j2
+++ b/roles/http_proxy/templates/front-end_conf.j2
@@ -91,12 +91,10 @@
       Require valid-user
   </Location>
 
-Alias /public /var/www/ood/public
-
-  <Directory /var/www/ood/public>
-      Options Indexes FollowSymLinks
-      AllowOverride None
-      Require all granted
-  </Directory>
+  <Location /public>
+    ProxyPreserveHost On
+    ProxyPass http://account-app/public
+    ProxyPassReverse http://account-app/public
+  </Location>
 
 </VirtualHost>

--- a/roles/http_proxy/templates/front-end_conf.j2
+++ b/roles/http_proxy/templates/front-end_conf.j2
@@ -91,6 +91,8 @@
       Require valid-user
   </Location>
 
+Alias /public /var/www/ood/public
+
   <Directory /var/www/ood/public>
       Options Indexes FollowSymLinks
       AllowOverride None

--- a/roles/http_proxy/templates/front-end_conf.j2
+++ b/roles/http_proxy/templates/front-end_conf.j2
@@ -91,4 +91,10 @@
       Require valid-user
   </Location>
 
+  <Directory /var/www/ood/public>
+      Options Indexes FollowSymLinks
+      AllowOverride None
+      Require all granted
+  </Directory>
+
 </VirtualHost>


### PR DESCRIPTION
This change is necessary to ensure that the contents of the `/var/www/ood/public` directory, such as static assets (e.g., logo), can be accessed without requiring user authentication