### PR TITLE
Issue seen: apache web restart was not working on the ood portal

### DIFF
--- a/roles/http_proxy/templates/front-end_conf.j2
+++ b/roles/http_proxy/templates/front-end_conf.j2
@@ -30,7 +30,7 @@
   LogLevel alert proxy:info
   LogLevel alert rewrite:info
 
-  <Location "/pun">
+  <LocationMatch "^/(pun|nginx|node|rnode)">
     AuthType shibboleth
     ShibRequestSetting requireSession 1
     Require valid-user
@@ -60,7 +60,7 @@
     #RewriteCond "%{LA-U:REMOTE_USER}" ^(.+)$
     RewriteCond "${grp:%1}" ^(.+)$
     RewriteRule .* "ws://%1%{REQUEST_URI}" [P,L]
-  </Location>
+  </LocationMatch>
 
   RedirectMatch ^/$ "/pun/sys/dashboard"
 


### PR DESCRIPTION
This happens since the locations /nginx, /node and /rnode arent defined locations in http proxy node. This PR adds the locations with the same stanza as /pun (as seen in ood-portal.conf) thus addressing the locations in http proxy