### PR TITLE
feat: Use upstream repo for sshpiper builds

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -349,8 +349,8 @@
   go_download_url: "https://go.dev/dl/go1.22.4.linux-amd64.tar.gz"
   go_download_path: "/tmp/go1.22.4.linux-amd64.tar.gz"
   go_binary_path: "/usr/local"
-  sshpiper_git_repo: "https://github.com/eesaanatluri/sshpiper"
-  sshpiper_version: "feat-routing-by-group"
+  sshpiper_git_repo: "https://github.com/tg123/sshpiper"
+  sshpiper_version: "95642617d36d6a5a4b51fee36d35ee4f898369ec"
   sshpiper_dest_dir: "/opt/sshpiper"
   sshpiper_bin_dir: "{{ sshpiper_dest_dir }}/out"
   sshpiper_bantime: 1200s


### PR DESCRIPTION
Since the group routing feature was merged upstream build from upstream